### PR TITLE
Remove CDN import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,27 +48,6 @@
       }
     }
   </script>
-<script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^19.1.0",
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "react/": "https://esm.sh/react@^19.1.0/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.7.0",
-    "framer-motion": "https://esm.sh/framer-motion@^12.19.1",
-    "jspdf": "https://esm.sh/jspdf@^3.0.1",
-    "html2canvas": "https://esm.sh/html2canvas@^1.4.1",
-    "jszip": "https://esm.sh/jszip@^3.10.1",
-    "@testing-library/jest-dom/": "https://esm.sh/@testing-library/jest-dom@^6.6.3/",
-    "@jest/globals": "https://esm.sh/@jest/globals@^30.0.3",
-    "@testing-library/react": "https://esm.sh/@testing-library/react@^16.3.0",
-    "@testing-library/jest-dom": "https://esm.sh/@testing-library/jest-dom@^6.6.3",
-    "zod": "https://esm.sh/zod@^3.25.67",
-    "@vitejs/plugin-react": "https://esm.sh/@vitejs/plugin-react@^4.6.0",
-    "vite": "https://esm.sh/vite@^7.0.0"
-  }
-}
-</script>
 <link rel="stylesheet" href="/index.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- avoid depending on CDN import maps by removing them from the app

## Testing
- `npm test --silent` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a53248108329bcec4d85f5a67b2d

## Summary by Sourcery

Enhancements:
- Delete the <script type="importmap"> block and its CDN import mappings from index.html