### PR TITLE
Add exclude section to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,6 @@
     "paths": {
       "@/*" :  ["./*"]
     }
-  }
+  },
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "node_modules", "coverage"]
 }


### PR DESCRIPTION
## Summary
- exclude test files and coverage from the TypeScript compiler

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a56279148329984196306bbc98ed

## Summary by Sourcery

Build:
- Add 'exclude' property to tsconfig.json with patterns for "**/*.test.ts", "**/*.test.tsx", "node_modules", and "coverage"