### PR TITLE
Fix createMockResponse formatting

### DIFF
--- a/services/metadataService.test.ts
+++ b/services/metadataService.test.ts
@@ -14,7 +14,8 @@ const validMetadata: AppMetadata = {
 };
 
 // Helper to create a partial Response object for mocking
-const createMockResponse = (body: any, ok: boolean, status: number, statusText: string): Response => ({
+const createMockResponse = (body: any, ok: boolean, status: number, statusText: string): Response =>
+  ({
     ok,
     json: async () => Promise.resolve(body), // Ensure json returns a Promise
     status,
@@ -30,7 +31,7 @@ const createMockResponse = (body: any, ok: boolean, status: number, statusText: 
     text: async () => Promise.resolve(JSON.stringify(body)),
     body: null,
     bodyUsed: false,
-  } as Response);
+  } as unknown as Response);
 
 
 describe('metadataService - getValidatedMetadata', () => {


### PR DESCRIPTION
## Summary
- format createMockResponse helper

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a5601ec48329a4265b55dba1c89d

## Summary by Sourcery

Refactor the createMockResponse test helper to improve formatting and correct its type assertion.

Enhancements:
- Reformat createMockResponse to use a multi-line arrow function return for better readability
- Change type assertion from “as Response” to “as unknown as Response” to satisfy TypeScript