### PR TITLE
Fix fileService import

### DIFF
--- a/services/fileService.ts
+++ b/services/fileService.ts
@@ -1,6 +1,6 @@
 
 import JSZip from 'jszip';
-import { Idea, Attachment, Project } from '../types';
+import { Idea, Project } from '../types';
 
 // Helper to convert Base64 to Blob
 export const base64ToBlob = (base64: string, type = 'application/octet-stream'): Blob => {


### PR DESCRIPTION
## Summary
- import only Idea and Project in fileService

## Testing
- `npm test --silent` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a559d1288329aef382cb1c88a9c8

## Summary by Sourcery

Bug Fixes:
- Remove unused Attachment import from fileService and import only Idea and Project