### PR TITLE
Add CSS module declarations

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## Summary
- declare CSS modules so TS handles `.css` imports

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a556fe6c8329815e52f2ea5ea599

## Summary by Sourcery

New Features:
- Declare '*.css' modules in a global type definition to enable .css imports