### PR TITLE
Fix Workbench unused parameter

### DIFF
--- a/components/Workbench.tsx
+++ b/components/Workbench.tsx
@@ -1,5 +1,5 @@
 // components/Workbench.tsx (Previously ProjectManager.tsx)
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Project } from '../types';
 import Button from './Button';
@@ -55,7 +55,7 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
     }
   }, [projectToDelete, addNotification, onDeleteProject]);
 
-  const handleToggleFavorite = (projectId: string) => {
+  const handleToggleFavorite = (_projectId: string) => {
     // Assuming there's a prop method for toggling favorite as well
     // onToggleFavorite(projectId);
   };


### PR DESCRIPTION
## Summary
- remove `useEffect` import from Workbench
- mark the favorite handler param unused

## Testing
- `npm test` *(fails: cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a550c008832981e6224d13ec2e04

## Summary by Sourcery

Enhancements:
- Prefix the handleToggleFavorite parameter with an underscore to indicate it’s unused