### PR TITLE
Fix test import

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,5 @@
 
-import '@testing-library/jest-dom/extend-expect'; // Use more explicit import for type augmentation
+import '@testing-library/jest-dom'; // Import matchers
 import { jest, beforeEach, afterEach } from '@jest/globals';
 
 // Mock localStorage for tests

--- a/services/metadataService.test.ts
+++ b/services/metadataService.test.ts
@@ -1,7 +1,7 @@
 
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import { getValidatedMetadata } from "./metadataService"; // Adjust path as necessary
-import { AppMetadata, AppMetadataSchema } from '../types/Metadata'; // Adjust path as necessary
+import { AppMetadata } from '../types/Metadata'; // Adjust path as necessary
 
 // Mock globalThis.fetch
 const mockFetch = jest.spyOn(globalThis, 'fetch');


### PR DESCRIPTION
## Summary
- update jest setup to use `@testing-library/jest-dom`
- correct `metadataService.test.ts` to import only `AppMetadata`

## Testing
- `npm test` *(fails: coverage thresholds unmet)*

------
https://chatgpt.com/codex/tasks/task_e_6861a56ab5a083298cc51f1e59db9aaf