### PR TITLE
Fix imports in localStorageService test

### DIFF
--- a/services/localStorageService.test.ts
+++ b/services/localStorageService.test.ts
@@ -1,7 +1,7 @@
 
 
-import { GoogleGenAI, GenerateContentResponse as GenAIResponse, GenerateContentParameters as GenAIParameters } from '@google/genai';
-import { describe, test, expect, beforeEach, jest, afterEach } from '@jest/globals';
+import { GenerateContentResponse as GenAIResponse, GenerateContentParameters as GenAIParameters } from '@google/genai';
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import * as localStorageServiceOriginal from './localStorageService'; // Adjust path
 import { Project, Idea } from '../types'; // Adjust path
 // Import types from @google/genai directly for mocking clarity


### PR DESCRIPTION
## Summary
- remove `GoogleGenAI` from the `@google/genai` import
- drop `afterEach` from the `@jest/globals` import

## Testing
- `npm test --silent` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a55ce81c83298df2a2dd455b2ddc

## Summary by Sourcery

Fix import statements in localStorageService test to remove unused and unnecessary imports

Tests:
- Remove GoogleGenAI from the @google/genai import
- Drop afterEach import from @jest/globals
- Add import for @testing-library/jest-dom/extend-expect to satisfy test requirements