### PR TITLE
Fix React imports

### DIFF
--- a/hooks/useUndoRedo.tsx
+++ b/hooks/useUndoRedo.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useRef, useState, ReactNode } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 interface HistoryState<T> {
   past: T[];
@@ -73,7 +73,13 @@ interface AppState {
 
 const UndoRedoContext = createContext<UndoRedoContextType<AppState> | undefined>(undefined);
 
-export const UndoRedoProvider = ({ children, initialState }: { children: ReactNode; initialState: AppState }) => {
+export const UndoRedoProvider = ({
+  children,
+  initialState,
+}: {
+  children: import('react').ReactNode;
+  initialState: AppState;
+}) => {
   const value = useUndoRedo<AppState>(initialState);
   return <UndoRedoContext.Provider value={value}>{children}</UndoRedoContext.Provider>;
 };


### PR DESCRIPTION
## Summary
- cleanup React imports in useUndoRedo hook

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a5558a308329a6a59831ee6feca6

## Summary by Sourcery

Clean up React imports in the useUndoRedo hook by removing the default React import and unused hooks, and inline the ReactNode type import.

Enhancements:
- Remove default React import and unused "useRef" import in useUndoRedo hook
- Inline ReactNode type import instead of importing it directly from React