### PR TITLE
Fix import in useTheme

### DIFF
--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 // hooks/useTheme.ts
 import { useState, useEffect, useCallback } from 'react';
-import { themes, ThemeName, ThemeProperties } from '../styles/theme'; // Updated import path
+import { themes, ThemeName } from '../styles/theme';
 
 const THEME_STORAGE_KEY = 'ideaforge-ascension-theme';
 


### PR DESCRIPTION
## Summary
- simplify useTheme import

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_6861a55366a883298d124baccdc6118f

## Summary by Sourcery

Enhancements:
- Remove unused `ThemeProperties` import from `useTheme` to streamline theme module usage.