### PR TITLE
Configure Jest for ts-jest ESM preset

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,13 +1,24 @@
 // jest.config.cjs
 module.exports = {
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src', '<rootDir>/components', '<rootDir>/services', '<rootDir>/hooks', '<rootDir>/utils'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx', '.mts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          module: 'ESNext',
+        },
+      },
+    ],
   },
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js',
+    '^@google/genai$': '<rootDir>/node_modules/@google/genai/dist/index.cjs',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   collectCoverage: true,


### PR DESCRIPTION
## Summary
- configure ts-jest preset for ESM modules
- map `@google/genai` to its CJS build for tests

## Testing
- `npm test` *(fails: Cannot access 'mockGenerateContentFn' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_6861a916e0a08329a99d1318adecbb90