### PR TITLE
Add jsPDF and html2canvas mocks

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,24 @@
 import '@testing-library/jest-dom'; // Use more explicit import for type augmentation
 import { jest, beforeEach, afterEach } from '@jest/globals';
 
+// Mock jsPDF and html2canvas used in PDF export utilities
+jest.mock('jspdf', () => {
+  return {
+    default: jest.fn().mockImplementation(() => ({
+      addImage: jest.fn(),
+      save: jest.fn(),
+      getImageProperties: jest.fn(() => ({ width: 1, height: 1 })),
+      internal: {
+        pageSize: {
+          getWidth: () => 595,
+          getHeight: () => 842,
+        },
+      },
+    })),
+  };
+});
+jest.mock('html2canvas', () => jest.fn(async () => document.createElement('canvas')));
+
 // Mock localStorage for tests
 const localStorageMock = (() => {
   let store: { [key: string]: string } = {};


### PR DESCRIPTION
## Summary
- add `jspdf` and `html2canvas` mocks in jest setup
- run `npm test` to verify IdeaEditor tests run without canvas issues

## Testing
- `npm test` *(fails: JSZip redefinition, genai ESM parsing, invalid component import, coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_6861a91b48148329b7f631b42871f91a