### PR TITLE
Fix fetch setup for metadata service tests

### DIFF
--- a/services/metadataService.test.ts
+++ b/services/metadataService.test.ts
@@ -3,8 +3,11 @@ import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import { getValidatedMetadata } from "./metadataService"; // Adjust path as necessary
 import { AppMetadata } from '../types/Metadata'; // Adjust path as necessary
 
-// Mock globalThis.fetch
-const mockFetch = jest.spyOn(globalThis, 'fetch');
+// Stub global fetch for the test environment
+(globalThis as any).fetch = jest.fn();
+
+// Reference the stubbed fetch for easier mocking in tests
+const mockFetch = globalThis.fetch as jest.MockedFunction<typeof fetch>;
 
 const validMetadata: AppMetadata = {
   name: "IdeaForge Local Test",


### PR DESCRIPTION
## Summary
- stub `globalThis.fetch` in `metadataService.test.ts`
- update tests to use the stub directly

## Testing
- `npm test` *(fails: JSZip and other issues, but metadata service no longer errors on fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6861a91ed1b0832987f821f271be871c

## Summary by Sourcery

Fix fetch mocking setup in metadataService tests by stubbing global fetch and adjusting tests to use the stubbed function.

Bug Fixes:
- Replace jest.spyOn global fetch with a direct fetch stub in metadataService tests
- Ensure fetch is referenced as a mocked function for easier test mocking

Tests:
- Update metadataService tests to use the new fetch stub directly