### PR TITLE
Remove unused React import

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 // components/ErrorBoundary.tsx
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode } from 'react';
 import Button from './Button'; // Assuming Button component is in the same directory or accessible
 import { ExclamationTriangleIcon } from './icons'; // Assuming an icon component
 


### PR DESCRIPTION
## Summary
- clean up ErrorBoundary by removing unused React import

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6861a921f0088329839fe1e3223837e6

## Summary by Sourcery

Enhancements:
- Remove unused React import from ErrorBoundary.tsx