### PR TITLE
Replace console logs with logger

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -245,6 +245,7 @@ const App: React.FC = () => {
         <ContactPanel
           isOpen={isContactPanelOpen}
           onClose={() => setIsContactPanelOpen(false)}
+          addNotification={addNotification}
         />
 
         {showOnboarding && (

--- a/components/ContactPanel.tsx
+++ b/components/ContactPanel.tsx
@@ -5,10 +5,12 @@ import Button from './Button';
 import TextInput from './TextInput';
 import TextArea from './TextArea';
 import { XMarkIcon, PaperAirplaneIcon } from './icons';
+import * as logger from '../services/logger';
 
 interface ContactPanelProps {
   isOpen: boolean;
   onClose: () => void;
+  addNotification: (message: string, type: 'success' | 'error' | 'info') => void;
 }
 
 const panelVariants: Variants = { // Explicitly typed with Variants
@@ -17,7 +19,7 @@ const panelVariants: Variants = { // Explicitly typed with Variants
   exit: { y: '100%', opacity: 0, transition: { ease: 'anticipate', duration: 0.4 } },
 };
 
-const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose }) => {
+const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose, addNotification }) => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
@@ -31,17 +33,19 @@ const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose }) => {
     // Simulate API call
     await new Promise(resolve => setTimeout(resolve, 1500));
     // Replace with actual form submission logic (e.g., to Formspree, Netlify Forms, or backend)
-    console.log('Form submitted:', { name, email, message });
+    logger.info('Contact form submitted', { name, email, message });
     setIsSubmitting(false);
     if (Math.random() > 0.1) { // Simulate mostly success
         setSubmitStatus('success');
         setName(''); setEmail(''); setMessage('');
+        addNotification('Transmission sent successfully.', 'success');
         setTimeout(() => {
             setSubmitStatus(null);
-            onClose(); 
+            onClose();
         }, 3000);
     } else {
         setSubmitStatus('error');
+        addNotification('Transmission failed to send.', 'error');
     }
   };
 

--- a/services/logger.ts
+++ b/services/logger.ts
@@ -1,0 +1,13 @@
+export const info = (...args: unknown[]): void => {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.info(...args);
+  }
+};
+
+export const error = (...args: unknown[]): void => {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error(...args);
+  }
+};

--- a/utils/zineExporter.ts
+++ b/utils/zineExporter.ts
@@ -1,6 +1,7 @@
 // utils/zineExporter.ts
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
+import * as logger from '../services/logger';
 
 // Custom hook for sorting/filtering ideas
 import { useMemo } from 'react';
@@ -86,7 +87,7 @@ export const exportViewAsPdfZine = async (options: ZineExportOptions = {}): Prom
     }
 
     pdf.save(filename);
-    console.log(`Zine exported as ${filename}`);
+    logger.info(`Zine exported as ${filename}`);
 
   } catch (error) {
     console.error("Error exporting Zine:", error);


### PR DESCRIPTION
## Summary
- add simple logging utility
- use logger in ContactPanel and Zine exporter
- notify users when contact panel submissions succeed or fail
- pass notification prop to ContactPanel

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6861a939f0a483299ea04dc8837ca305

## Summary by Sourcery

Introduce a simple logger service, replace direct console calls with structured logging, and integrate user notifications into the contact form flow.

New Features:
- Add a logger service exposing info and error methods.
- Show success and error notifications on contact form submissions via addNotification.

Enhancements:
- Replace console.log and console.error calls with logger.info and logger.error in ContactPanel and zineExporter.
- Pass addNotification callback from App into ContactPanel to trigger notifications.