### PR TITLE
Add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to IdeaForge Local
+
+Thank you for your interest in improving IdeaForge Local! This guide explains how to set up the project for development, run the test suite, and submit pull requests.
+
+## Development Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd <repository-directory>
+   ```
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+3. **Optional: configure environment variables**
+   If you plan to use the optional AI features, create a `.env` file in the project root and add your Gemini API key:
+   ```env
+   API_KEY=YOUR_GEMINI_API_KEY
+   ```
+
+## Running Tests
+
+Before opening a pull request, make sure the codebase passes linting, formatting, and unit tests:
+
+```bash
+npm run lint
+npm run format
+npm test
+```
+
+To generate a coverage report, run:
+
+```bash
+npm test -- --coverage
+```
+
+## Submitting Pull Requests
+
+1. Create a feature branch based on `main`.
+2. Commit your changes with clear messages and push the branch to your fork.
+3. Open a pull request describing the changes and the motivation behind them.
+4. Ensure your branch passes all CI checks before requesting a review.
+
+We appreciate your contributions!

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ IdeaForge Local is a privacy-first, local-only ideation and project management t
 A GitHub Actions workflow (`.github/workflows/ci.yml`) runs linting, formatting, and tests on every push to ensure code quality.
 
 ## Contributing
-Contributions are welcome! Please open an issue or pull request with your suggestions or improvements. See `CONTRIBUTING.md` for guidelines (if available).
+Contributions are welcome! Please open an issue or pull request with your suggestions or improvements. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 Specify your license here (e.g., MIT, Apache 2.0).


### PR DESCRIPTION
## Summary
- add project setup and pull request instructions in `CONTRIBUTING.md`
- update README to link to the new guide

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run format`
- `npm test` *(fails: 5 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861adcdf0d0832984357eddf53fe366

## Summary by Sourcery

Add a CONTRIBUTING guide with development setup, testing, and pull request guidelines, and update the README to link to it.

Documentation:
- Introduce CONTRIBUTING.md with development setup, test execution, and PR submission instructions
- Update README.md to reference the new CONTRIBUTING guide