### PR TITLE
Add env helper module

### DIFF
--- a/services/localStorageService.ts
+++ b/services/localStorageService.ts
@@ -1,10 +1,11 @@
 import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
 import { Project, Idea, SampleProject, Attachment } from '../types';
+import { API_KEY } from '../src/utils/env';
 
 // Initialize Gemini AI Client
 let ai: GoogleGenAI | null = null;
 try {
-  const apiKey = process.env.API_KEY;
+  const apiKey = API_KEY;
 
   if (apiKey) {
     ai = new GoogleGenAI({ apiKey });

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  API_KEY: z.string().optional(),
+});
+
+const parsedEnv = envSchema.parse(process.env);
+
+export const API_KEY = parsedEnv.API_KEY;
+export default parsedEnv;


### PR DESCRIPTION
## Summary
- add Zod-based env parser to expose API_KEY
- use env helper in localStorageService instead of direct process.env access

## Testing
- `npm test --silent` *(fails: Cannot access 'mockGenerateContentFn' before initialization)*
- `npm run lint` *(fails: 204 errors, 48 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6861ad93d5f0832997d165c74dfa9c03