### PR TITLE
Add basic i18n setup

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,6 +1,6 @@
-
 import React from 'react';
 import { motion, Variants, TargetAndTransition } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 
 interface LandingPageProps {
   onEnterForge: () => void;
@@ -30,7 +30,6 @@ const logoVariants: Variants = {
   },
 };
 
-
 const itemVariants: Variants = {
   hidden: { y: 20, opacity: 0 },
   visible: {
@@ -48,18 +47,17 @@ const buttonHover: TargetAndTransition = {
   transition: { type: 'spring', stiffness: 300 },
 };
 
-const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) => (
+const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) => {
+  const { t } = useTranslation();
+  return (
     <motion.div
       className="flex flex-col items-center justify-center min-h-screen text-center p-4 relative"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
     >
-      <motion.div 
-        variants={logoVariants}
-        className="pt-10 mb-6 z-10"
-      >
-        <motion.img 
+      <motion.div variants={logoVariants} className="pt-10 mb-6 z-10">
+        <motion.img
           src="https://cdn.jsdelivr.net/gh/agattone96/ideaforge/logo.png"
           alt="Cosmic Forge Logo"
           className="mx-auto w-full h-auto max-w-[300px] sm:max-w-[400px] drop-shadow-glow-pink"
@@ -69,7 +67,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) =>
           transition={{
             duration: 4,
             repeat: Infinity,
-            ease: "easeInOut",
+            ease: 'easeInOut',
           }}
         />
       </motion.div>
@@ -78,14 +76,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) =>
         variants={itemVariants}
         className="font-sans font-bold text-4xl sm:text-5xl md:text-6xl text-cosmic-text-primary uppercase tracking-wider mb-4"
       >
-        Welcome to IdeaForge
+        {t('welcome')}
       </motion.h1>
 
       <motion.p
         variants={itemVariants}
         className="font-body text-lg sm:text-xl text-cosmic-text-secondary mb-10"
       >
-        Think freely. Build clearly.
+        {t('tagline')}
       </motion.p>
 
       <motion.div
@@ -97,14 +95,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) =>
           className="w-full sm:w-auto px-10 py-4 font-body font-bold text-cosmic-text-primary bg-gradient-to-r from-cosmic-pink to-cosmic-orange rounded-xl shadow-lg shadow-cosmic-pink/20 hover:shadow-glow-lg transition-shadow duration-300"
           whileHover={buttonHover}
         >
-          Enter the Forge
+          {t('enter')}
         </motion.button>
         <motion.button
           onClick={onTryDemo}
           className="w-full sm:w-auto px-10 py-4 font-body font-bold text-cosmic-text-primary border-2 border-cosmic-pink rounded-xl bg-transparent hover:bg-gradient-to-r hover:from-cosmic-pink hover:to-cosmic-orange hover:border-transparent transition-all duration-300"
           whileHover={buttonHover}
         >
-          Try Demo
+          {t('demo')}
         </motion.button>
       </motion.div>
 
@@ -112,9 +110,10 @@ const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) =>
         variants={itemVariants}
         className="font-body text-sm text-cosmic-text-secondary uppercase tracking-[0.1em] absolute bottom-8"
       >
-        // Your Cosmic Forge Awaits //
+        {t('awaits')}
       </motion.p>
     </motion.div>
   );
+};
 
 export default LandingPage;

--- a/components/WelcomeScreen.tsx
+++ b/components/WelcomeScreen.tsx
@@ -1,99 +1,108 @@
 // components/WelcomeScreen.tsx
 import React from 'react';
 import { motion } from 'framer-motion';
-import RippleButton from './RippleButton'; 
-import { slideDown, staggerContainer, staggerItem } from '../motion/variants'; 
+import RippleButton from './RippleButton';
+import { slideDown, staggerContainer, staggerItem } from '../motion/variants';
 import { PlusCircleIcon, SparklesIcon } from './icons';
+import { useTranslation } from 'react-i18next';
 
 interface WelcomeScreenProps {
-  onGetStarted: () => void; 
+  onGetStarted: () => void;
   onImportSample: () => void;
 }
 
 const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onGetStarted, onImportSample }) => {
+  const { t } = useTranslation();
 
   const handleTryDemo = () => {
     onImportSample(); // This usually adds a notification
     // Potentially delay onGetStarted to allow notification to be seen, or rely on App.tsx flow
-    onGetStarted(); 
+    onGetStarted();
   };
-  
+
   return (
-      <motion.section
-        className="fixed inset-0 z-10 flex flex-col items-center justify-center p-space-sm sm:p-space-md text-center"
-        variants={slideDown} 
+    <motion.section
+      className="fixed inset-0 z-10 flex flex-col items-center justify-center p-space-sm sm:p-space-md text-center"
+      variants={slideDown}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      aria-labelledby="welcome-heading"
+    >
+      <motion.div
+        variants={staggerContainer} // Use stagger for inner elements
         initial="hidden"
         animate="visible"
-        exit="exit" 
-        aria-labelledby="welcome-heading"
+        className="w-full max-w-lg xl:max-w-xl relative glassmorphic p-6 sm:p-8 md:p-10 rounded-xl shadow-2xl border border-theme-border-accent/30"
       >
-        <motion.div 
-          variants={staggerContainer} // Use stagger for inner elements
-          initial="hidden"
-          animate="visible"
-          className="w-full max-w-lg xl:max-w-xl relative glassmorphic p-6 sm:p-8 md:p-10 rounded-xl shadow-2xl border border-theme-border-accent/30"
-        >
-          <motion.div variants={staggerItem} className="mb-4 sm:mb-6">
-            <img src="assets/images/logo.png" alt="IdeaForge Logo" className="w-36 h-auto sm:w-48 mx-auto filter drop-shadow-[0_0_15px_var(--color-accent-primary)]" />
-          </motion.div>
-          
-          <motion.h1 
-            id="welcome-heading" 
-            variants={staggerItem}
-            className="text-3xl sm:text-4xl md:text-5xl font-display font-bold text-theme-text-primary mb-2 sm:mb-3 uppercase tracking-[0.1em] sm:tracking-[0.15em]"
-            style={{ textShadow: '0 0 8px var(--color-accent-primary), 0 0 15px var(--color-accent-secondary)' }}
-          >
-            WELCOME TO IDEAFORGE
-          </motion.h1>
-          
-          <motion.p 
-            variants={staggerItem}
-            className="text-lg sm:text-xl font-body text-theme-accent-primary font-semibold mb-4 sm:mb-6"
-          >
-            Think freely. Build clearly.
-          </motion.p>
-
-          <motion.p 
-            variants={staggerItem}
-            className="text-sm sm:text-base text-theme-text-primary mb-6 sm:mb-8 font-body leading-relaxed max-w-md mx-auto"
-          >
-            A distraction-free environment for building connected thoughts, diagrams, and designs.
-          </motion.p>
-
-          <motion.div 
-            variants={staggerItem}
-            className="space-y-3 sm:space-y-0 sm:flex sm:justify-center sm:space-x-4"
-          >
-            <RippleButton 
-                onClick={handleTryDemo} 
-                variant="outline" 
-                size="lg" 
-                className="w-full sm:w-auto"
-                aria-label="Try a demo project and enter the application"
-                leftIcon={<PlusCircleIcon className="w-5 h-5" />}
-            >
-              Try Demo
-            </RippleButton>
-            <RippleButton 
-                onClick={onGetStarted} 
-                variant="glow" 
-                size="lg" 
-                className="w-full sm:w-auto"
-                aria-label="Enter the main application"
-                leftIcon={<SparklesIcon className="w-5 h-5"/>}
-            >
-             Enter the Forge
-            </RippleButton>
-          </motion.div>
-
-          <motion.p 
-            variants={staggerItem}
-            className="text-xs text-theme-text-secondary/80 mt-8 sm:mt-10 font-mono tracking-widest"
-          >
-            // YOUR COSMIC FORGE AWAITS //
-          </motion.p>
+        <motion.div variants={staggerItem} className="mb-4 sm:mb-6">
+          <img
+            src="assets/images/logo.png"
+            alt="IdeaForge Logo"
+            className="w-36 h-auto sm:w-48 mx-auto filter drop-shadow-[0_0_15px_var(--color-accent-primary)]"
+          />
         </motion.div>
-      </motion.section>
+
+        <motion.h1
+          id="welcome-heading"
+          variants={staggerItem}
+          className="text-3xl sm:text-4xl md:text-5xl font-display font-bold text-theme-text-primary mb-2 sm:mb-3 uppercase tracking-[0.1em] sm:tracking-[0.15em]"
+          style={{
+            textShadow:
+              '0 0 8px var(--color-accent-primary), 0 0 15px var(--color-accent-secondary)',
+          }}
+        >
+          {t('welcome')}
+        </motion.h1>
+
+        <motion.p
+          variants={staggerItem}
+          className="text-lg sm:text-xl font-body text-theme-accent-primary font-semibold mb-4 sm:mb-6"
+        >
+          {t('tagline')}
+        </motion.p>
+
+        <motion.p
+          variants={staggerItem}
+          className="text-sm sm:text-base text-theme-text-primary mb-6 sm:mb-8 font-body leading-relaxed max-w-md mx-auto"
+        >
+          {t('description')}
+        </motion.p>
+
+        <motion.div
+          variants={staggerItem}
+          className="space-y-3 sm:space-y-0 sm:flex sm:justify-center sm:space-x-4"
+        >
+          <RippleButton
+            onClick={handleTryDemo}
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto"
+            aria-label="Try a demo project and enter the application"
+            leftIcon={<PlusCircleIcon className="w-5 h-5" />}
+          >
+            {t('demo')}
+          </RippleButton>
+          <RippleButton
+            onClick={onGetStarted}
+            variant="glow"
+            size="lg"
+            className="w-full sm:w-auto"
+            aria-label="Enter the main application"
+            leftIcon={<SparklesIcon className="w-5 h-5" />}
+          >
+            {t('enter')}
+          </RippleButton>
+        </motion.div>
+
+        <motion.p
+          variants={staggerItem}
+          className="text-xs text-theme-text-secondary/80 mt-8 sm:mt-10 font-mono tracking-widest"
+        >
+          {t('awaits')}
+        </motion.p>
+      </motion.div>
+    </motion.section>
   );
 };
 

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,19 @@
+import * as i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en/translation.json';
+import es from './locales/es/translation.json';
+
+const i18n = i18next.createInstance();
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    es: { translation: es },
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/index.tsx
+++ b/index.tsx
@@ -2,18 +2,22 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './src/index.css';
 import App from './App';
-import ErrorBoundary from './components/ErrorBoundary'; // Import the ErrorBoundary
+import ErrorBoundary from './components/ErrorBoundary';
+import { I18nextProvider } from 'react-i18next';
+import i18n from './i18n';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  throw new Error("Could not find root element to mount to");
+  throw new Error('Could not find root element to mount to');
 }
 
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <I18nextProvider i18n={i18n}>
+        <App />
+      </I18nextProvider>
     </ErrorBoundary>
   </React.StrictMode>
 );

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom'; // Use more explicit import for type augmentation
 import { jest, beforeEach, afterEach } from '@jest/globals';
+import './i18n';
 
 // Mock localStorage for tests
 const localStorageMock = (() => {
@@ -59,7 +60,7 @@ if (typeof (window as any).JSZip === 'undefined') {
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn().mockImplementation(query => ({
+  value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,8 @@
+{
+  "welcome": "Welcome to IdeaForge",
+  "tagline": "Think freely. Build clearly.",
+  "description": "A distraction-free environment for building connected thoughts, diagrams, and designs.",
+  "enter": "Enter the Forge",
+  "demo": "Try Demo",
+  "awaits": "// Your Cosmic Forge Awaits //"
+}

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -1,0 +1,8 @@
+{
+  "welcome": "Bienvenido a IdeaForge",
+  "tagline": "Piensa libremente. Construye con claridad.",
+  "description": "Un entorno sin distracciones para crear pensamientos, diagramas y diseños conectados.",
+  "enter": "Entrar en la forja",
+  "demo": "Probar demo",
+  "awaits": "// Tu forja cósmica te espera //"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,17 @@
     "": {
       "name": "ideaforge-ascension",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.7.0",
         "framer-motion": "^12.19.2",
         "html2canvas": "^1.4.1",
+        "i18next": "^25.2.1",
         "jspdf": "^3.0.1",
         "jszip": "^3.10.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-i18next": "^15.5.3",
         "zod": "^3.25.67"
       },
       "devDependencies": {
@@ -6863,6 +6866,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -6925,6 +6937,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
+      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -12193,6 +12236,32 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.3.tgz",
+      "integrity": "sha512-ypYmOKOnjqPEJZO4m1BI0kS8kWqkBNsKYyhVUfij0gvjy9xJNoG/VcGkxq5dRlVwzmrmY1BQMAmpbbUBLwC4Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13731,7 +13800,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14214,6 +14283,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "jszip": "^3.10.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "i18next": "^25.2.1",
+    "react-i18next": "^15.5.3",
     "zod": "^3.25.67"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- integrate react-i18next with initialization file
- provide English and Spanish translations
- wire I18nextProvider at the app root
- use translations on LandingPage and WelcomeScreen
- load i18n during tests

## Testing
- `npm test` *(fails: Property `fetch` does not exist ...)*

------
https://chatgpt.com/codex/tasks/task_e_6861ad8f4f588329a4666d3d1d058fc5

## Summary by Sourcery

Set up basic internationalization by configuring react-i18next, wiring the provider at the app root, localizing components, and ensuring translations load in tests.

New Features:
- Initialize react-i18next with English and Spanish locale resources.

Enhancements:
- Wrap the application root in I18nextProvider and import the i18n instance.
- Replace hardcoded UI strings in LandingPage and WelcomeScreen with useTranslation hooks.
- Load the i18n configuration in Jest setup to enable translations during tests.

Build:
- Add i18next and react-i18next dependencies to package.json.