### PR TITLE
Apply prettier and enforce newline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,12 +22,7 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
     'prettier',
   ],
-  plugins: [
-    'react',
-    '@typescript-eslint',
-    'react-hooks',
-    'jsx-a11y',
-  ],
+  plugins: ['react', '@typescript-eslint', 'react-hooks', 'jsx-a11y'],
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-filename-extension': [1, { extensions: ['.tsx', '.jsx'] }],

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "singleQuote": true,
   "trailingComma": "es5",
-  "semi": true
+  "semi": true,
+  "endOfLine": "lf"
 }

--- a/App.test.tsx
+++ b/App.test.tsx
@@ -1,5 +1,3 @@
-
-
 import React, { useEffect } from 'react';
 import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -7,9 +5,10 @@ import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globa
 import App from './App'; // Adjust path as necessary
 import ErrorBoundary from './components/ErrorBoundary'; // Import ErrorBoundary
 
-
 // Mock child components that might have complex logic or side effects
-jest.mock('./components/WelcomeScreen', () => () => <div data-testid="welcome-screen">Welcome Screen</div>);
+jest.mock('./components/WelcomeScreen', () => () => (
+  <div data-testid="welcome-screen">Welcome Screen</div>
+));
 jest.mock('./components/Workbench', () => () => <div data-testid="workbench">Workbench</div>);
 // Add mocks for other components like IdeaList, IdeaEditor, SettingsModal, ContactPanel, NotificationArea if they cause issues or for isolation
 
@@ -19,8 +18,8 @@ describe('App Component', () => {
     localStorage.clear();
     // Mock navigator.onLine
     Object.defineProperty(navigator, 'onLine', {
-        configurable: true,
-        value: true,
+      configurable: true,
+      value: true,
     });
   });
 
@@ -29,7 +28,7 @@ describe('App Component', () => {
     render(<App />);
     // Wait for initial loader to hide
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 600)); // Wait for initialLoadComplete timeout + buffer
+      await new Promise((resolve) => setTimeout(resolve, 600)); // Wait for initialLoadComplete timeout + buffer
     });
     expect(screen.getByTestId('welcome-screen')).toBeInTheDocument();
   });
@@ -37,9 +36,9 @@ describe('App Component', () => {
   test('renders Workbench if not the first visit', async () => {
     localStorage.setItem('IDEA_FORGE_LOCAL_FIRST_VISIT_DONE', 'true');
     render(<App />);
-     // Wait for initial loader to hide
+    // Wait for initial loader to hide
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 600));
+      await new Promise((resolve) => setTimeout(resolve, 600));
     });
     expect(screen.getByTestId('workbench')).toBeInTheDocument();
     expect(screen.queryByTestId('welcome-screen')).not.toBeInTheDocument();
@@ -49,7 +48,7 @@ describe('App Component', () => {
     localStorage.setItem('IDEA_FORGE_LOCAL_FIRST_VISIT_DONE', 'true');
     render(<App />);
     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 600));
+      await new Promise((resolve) => setTimeout(resolve, 600));
     });
     expect(screen.getByLabelText('Open Settings')).toBeInTheDocument();
     expect(screen.getByLabelText('Open Contact Panel')).toBeInTheDocument();
@@ -61,17 +60,16 @@ describe('App Component', () => {
     const statusElement = document.getElementById('connection-status');
     expect(statusElement).toBeInTheDocument();
     // Allow useEffect to run
-     await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 100)); // Short wait for useEffect
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100)); // Short wait for useEffect
     });
     expect(statusElement?.textContent).toBe('Cosmic Link: Stable');
   });
 
   describe('ErrorBoundary Integration', () => {
     // Mock console.error to prevent Jest from outputting caught errors during tests
-     
-    let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
 
+    let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
 
     beforeEach(() => {
       consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -83,7 +81,8 @@ describe('App Component', () => {
 
     test('ErrorBoundary catches errors and displays fallback UI', () => {
       const ThrowErrorComponent = () => {
-        useEffect(() => { // Throw error after initial render in an effect
+        useEffect(() => {
+          // Throw error after initial render in an effect
           throw new Error('Test error from child');
         }, []);
         return null;

--- a/App.tsx
+++ b/App.tsx
@@ -36,8 +36,15 @@ const App: React.FC = () => {
 
   // Theme Management
   const { currentThemeName, setTheme, availableThemes } = useTheme();
-  const { state: undoRedoState, set: setProjectsState, undo, redo, canUndo, canRedo } = useUndoRedoContext();
-  const {projects} = undoRedoState.present;
+  const {
+    state: undoRedoState,
+    set: setProjectsState,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+  } = useUndoRedoContext();
+  const { projects } = undoRedoState.present;
 
   // Load accessibility settings on startup
   useEffect(() => {
@@ -58,13 +65,16 @@ const App: React.FC = () => {
     setPrefersReducedMotion(enabled);
   };
 
-  const addNotification = useCallback((message: string, type: NotificationType['type'] = 'info') => {
-    const newNotification: NotificationType = { id: crypto.randomUUID(), message, type };
-    setNotifications(current => [...current, newNotification]);
-  }, []);
+  const addNotification = useCallback(
+    (message: string, type: NotificationType['type'] = 'info') => {
+      const newNotification: NotificationType = { id: crypto.randomUUID(), message, type };
+      setNotifications((current) => [...current, newNotification]);
+    },
+    []
+  );
 
   const dismissNotification = useCallback((id: string) => {
-    setNotifications(current => current.filter(n => n.id !== id));
+    setNotifications((current) => current.filter((n) => n.id !== id));
   }, []);
 
   const handleEnterForge = () => setAppView('projectManager');
@@ -82,7 +92,7 @@ const App: React.FC = () => {
   };
 
   const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
-  const currentProject = projects.find(p => p.id === currentProjectId) || null;
+  const currentProject = projects.find((p) => p.id === currentProjectId) || null;
 
   // Update onBackToProjects to clear currentProjectId
   const handleBackToProjects = useCallback(() => {
@@ -108,87 +118,127 @@ const App: React.FC = () => {
   }, []);
 
   // Handler to create a new project
-  const handleCreateProject = useCallback((projectName: string) => {
-    const newProject: Project = {
-      id: crypto.randomUUID(),
-      name: projectName,
-      ideas: [],
-      attachments: [],
-      logo: undefined,
-      createdAt: new Date().toISOString(),
-      isFavorite: false,
-    };
-    const updatedProjects = [newProject, ...projects];
-    setProjectsState({ projects: updatedProjects });
-    localStorageService.saveProjects(updatedProjects);
-    setCurrentProjectId(newProject.id);
-    setAppView('ideaList');
-    addNotification(`Constellation "${newProject.name}" successfully ignited!`, 'success');
-  }, [projects, setProjectsState, addNotification]);
+  const handleCreateProject = useCallback(
+    (projectName: string) => {
+      const newProject: Project = {
+        id: crypto.randomUUID(),
+        name: projectName,
+        ideas: [],
+        attachments: [],
+        logo: undefined,
+        createdAt: new Date().toISOString(),
+        isFavorite: false,
+      };
+      const updatedProjects = [newProject, ...projects];
+      setProjectsState({ projects: updatedProjects });
+      localStorageService.saveProjects(updatedProjects);
+      setCurrentProjectId(newProject.id);
+      setAppView('ideaList');
+      addNotification(`Constellation "${newProject.name}" successfully ignited!`, 'success');
+    },
+    [projects, setProjectsState, addNotification]
+  );
 
   // Handler to update a project (e.g., add/edit idea)
-  const handleUpdateProject = useCallback((updatedProject: Project) => {
-    const updatedProjects = projects.map(p => p.id === updatedProject.id ? updatedProject : p);
-    setProjectsState({ projects: updatedProjects });
-    localStorageService.saveProjects(updatedProjects);
-    setCurrentProjectId(updatedProject.id);
-  }, [projects, setProjectsState]);
+  const handleUpdateProject = useCallback(
+    (updatedProject: Project) => {
+      const updatedProjects = projects.map((p) =>
+        p.id === updatedProject.id ? updatedProject : p
+      );
+      setProjectsState({ projects: updatedProjects });
+      localStorageService.saveProjects(updatedProjects);
+      setCurrentProjectId(updatedProject.id);
+    },
+    [projects, setProjectsState]
+  );
 
   // Handler to delete a project
-  const handleDeleteProject = useCallback((projectId: string) => {
-    const updatedProjects = projects.filter(p => p.id !== projectId);
-    setProjectsState({ projects: updatedProjects });
-    localStorageService.saveProjects(updatedProjects);
-    setCurrentProjectId(null);
-    setAppView('projectManager');
-    addNotification('Constellation has faded into the void.', 'success');
-  }, [projects, setProjectsState, addNotification]);
+  const handleDeleteProject = useCallback(
+    (projectId: string) => {
+      const updatedProjects = projects.filter((p) => p.id !== projectId);
+      setProjectsState({ projects: updatedProjects });
+      localStorageService.saveProjects(updatedProjects);
+      setCurrentProjectId(null);
+      setAppView('projectManager');
+      addNotification('Constellation has faded into the void.', 'success');
+    },
+    [projects, setProjectsState, addNotification]
+  );
 
   // Handler to add/edit/delete ideas within a project
-  const handleSaveIdea = useCallback((updatedProject: Project) => {
-    handleUpdateProject(updatedProject);
-    setIdeaToEdit(null);
-    setAppView('ideaList');
-  }, [handleUpdateProject]);
+  const handleSaveIdea = useCallback(
+    (updatedProject: Project) => {
+      handleUpdateProject(updatedProject);
+      setIdeaToEdit(null);
+      setAppView('ideaList');
+    },
+    [handleUpdateProject]
+  );
 
   // Pass new handlers and state to children
   const renderView = () => {
     switch (appView) {
       case 'landing':
-        return <LandingPage key="landing" onEnterForge={handleEnterForge} onTryDemo={handleTryDemo} />;
+        return (
+          <LandingPage key="landing" onEnterForge={handleEnterForge} onTryDemo={handleTryDemo} />
+        );
       case 'projectManager':
-        return <Workbench 
-          key="workbench"
-          projects={projects}
-          onProjectSelected={(project) => { setCurrentProjectId(project.id); setAppView('ideaList'); }}
-          onCreateProject={handleCreateProject}
-          onDeleteProject={handleDeleteProject}
-          addNotification={addNotification}
-          onQuickNewIdea={(project) => { setCurrentProjectId(project.id); setAppView('ideaEditor'); }}
-        />;
+        return (
+          <Workbench
+            key="workbench"
+            projects={projects}
+            onProjectSelected={(project) => {
+              setCurrentProjectId(project.id);
+              setAppView('ideaList');
+            }}
+            onCreateProject={handleCreateProject}
+            onDeleteProject={handleDeleteProject}
+            addNotification={addNotification}
+            onQuickNewIdea={(project) => {
+              setCurrentProjectId(project.id);
+              setAppView('ideaEditor');
+            }}
+          />
+        );
       case 'ideaList':
-        if (!currentProject) { handleBackToProjects(); return null; }
-        return <IdeaList 
-          key={`ideelist-${currentProject.id}`}
-          project={currentProject}
-          onEditIdea={handleEditIdea}
-          onCreateNewIdea={handleCreateNewIdea}
-          onBackToProjects={handleBackToProjects}
-          addNotification={addNotification}
-          onUpdateProject={handleUpdateProject}
-        />;
+        if (!currentProject) {
+          handleBackToProjects();
+          return null;
+        }
+        return (
+          <IdeaList
+            key={`ideelist-${currentProject.id}`}
+            project={currentProject}
+            onEditIdea={handleEditIdea}
+            onCreateNewIdea={handleCreateNewIdea}
+            onBackToProjects={handleBackToProjects}
+            addNotification={addNotification}
+            onUpdateProject={handleUpdateProject}
+          />
+        );
       case 'ideaEditor':
-        if (!currentProject) { handleBackToProjects(); return null; }
-        return <IdeaEditor 
-          key={`ideaeditor-${ideaToEdit?.id || 'new'}`}
-          project={currentProject}
-          ideaToEdit={ideaToEdit}
-          onSave={handleSaveIdea}
-          onCancel={handleBackToProjects}
-          addNotification={addNotification}
-        />;
+        if (!currentProject) {
+          handleBackToProjects();
+          return null;
+        }
+        return (
+          <IdeaEditor
+            key={`ideaeditor-${ideaToEdit?.id || 'new'}`}
+            project={currentProject}
+            ideaToEdit={ideaToEdit}
+            onSave={handleSaveIdea}
+            onCancel={handleBackToProjects}
+            addNotification={addNotification}
+          />
+        );
       default:
-        return <LandingPage key="default-landing" onEnterForge={handleEnterForge} onTryDemo={handleTryDemo} />;
+        return (
+          <LandingPage
+            key="default-landing"
+            onEnterForge={handleEnterForge}
+            onTryDemo={handleTryDemo}
+          />
+        );
     }
   };
 
@@ -201,28 +251,54 @@ const App: React.FC = () => {
       <div className="font-body text-theme-text-primary min-h-screen">
         <CosmicCanvas />
         <main id="main-content" className="relative z-10">
-          <AnimatePresence mode="wait">
-            {renderView()}
-          </AnimatePresence>
+          <AnimatePresence mode="wait">{renderView()}</AnimatePresence>
         </main>
         {/* Undo/Redo Controls */}
         <div className="fixed bottom-4 left-4 z-[60] flex gap-2">
-          <Button variant="glow" size="md" onClick={undo} disabled={!canUndo} aria-label="Undo" title="Undo (Ctrl+Z)">
+          <Button
+            variant="glow"
+            size="md"
+            onClick={undo}
+            disabled={!canUndo}
+            aria-label="Undo"
+            title="Undo (Ctrl+Z)"
+          >
             ⎌ Undo
           </Button>
-          <Button variant="glow" size="md" onClick={redo} disabled={!canRedo} aria-label="Redo" title="Redo (Ctrl+Y)">
+          <Button
+            variant="glow"
+            size="md"
+            onClick={redo}
+            disabled={!canRedo}
+            aria-label="Redo"
+            title="Redo (Ctrl+Y)"
+          >
             ↻ Redo
           </Button>
         </div>
         {appView !== 'landing' && (
           <>
             <div className="fixed bottom-4 right-[calc(4rem+1rem)] z-[60]">
-              <Button variant="glow" size="lg" className="rounded-full !p-3 shadow-lg" onClick={() => setIsSettingsModalOpen(true)} aria-label="Open Settings" prefersReducedMotion={prefersReducedMotion}>
+              <Button
+                variant="glow"
+                size="lg"
+                className="rounded-full !p-3 shadow-lg"
+                onClick={() => setIsSettingsModalOpen(true)}
+                aria-label="Open Settings"
+                prefersReducedMotion={prefersReducedMotion}
+              >
                 <CogIcon className="w-6 h-6" />
               </Button>
             </div>
             <div className="fixed bottom-4 right-4 z-[60]">
-              <Button variant="glow" size="lg" className="rounded-full !p-3 shadow-lg" onClick={() => setIsContactPanelOpen(true)} aria-label="Open Contact Panel" prefersReducedMotion={prefersReducedMotion}>
+              <Button
+                variant="glow"
+                size="lg"
+                className="rounded-full !p-3 shadow-lg"
+                onClick={() => setIsContactPanelOpen(true)}
+                aria-label="Open Contact Panel"
+                prefersReducedMotion={prefersReducedMotion}
+              >
                 <EnvelopeIcon className="w-6 h-6" />
               </Button>
             </div>
@@ -230,7 +306,7 @@ const App: React.FC = () => {
         )}
 
         <NotificationArea notifications={notifications} onDismiss={dismissNotification} />
-        
+
         <SettingsModal
           isOpen={isSettingsModalOpen}
           onClose={() => setIsSettingsModalOpen(false)}
@@ -241,18 +317,28 @@ const App: React.FC = () => {
           prefersReducedMotion={prefersReducedMotion}
           onReducedMotionChange={handleReducedMotionChange}
         />
-        
-        <ContactPanel
-          isOpen={isContactPanelOpen}
-          onClose={() => setIsContactPanelOpen(false)}
-        />
+
+        <ContactPanel isOpen={isContactPanelOpen} onClose={() => setIsContactPanelOpen(false)} />
 
         {showOnboarding && (
-          <Modal isOpen={showOnboarding} onClose={() => setShowOnboarding(false)} title="Welcome to IdeaForge!">
+          <Modal
+            isOpen={showOnboarding}
+            onClose={() => setShowOnboarding(false)}
+            title="Welcome to IdeaForge!"
+          >
             <div className="space-y-4">
               <h2 className="text-xl font-bold">Welcome to IdeaForge 🚀</h2>
-              <p>Start by creating your first constellation (project) or try the demo. Use the settings to personalize your experience. Need help? Click the contact button!</p>
-              <Button variant="default" onClick={() => setShowOnboarding(false)} aria-label="Close onboarding">Get Started</Button>
+              <p>
+                Start by creating your first constellation (project) or try the demo. Use the
+                settings to personalize your experience. Need help? Click the contact button!
+              </p>
+              <Button
+                variant="default"
+                onClick={() => setShowOnboarding(false)}
+                aria-label="Close onboarding"
+              >
+                Get Started
+              </Button>
             </div>
           </Modal>
         )}

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ IdeaForge Local is a privacy-first, local-only ideation and project management t
 ## Getting Started
 
 ### Prerequisites
+
 - **Node.js** v18.x or later
 - **npm** v9.x or later (or `yarn`/`pnpm`)
 
 ### Installation
+
 1. **Clone the Repository:**
    ```bash
    git clone <repository-url>
@@ -50,6 +52,7 @@ IdeaForge Local is a privacy-first, local-only ideation and project management t
    The app will be available at `http://localhost:3000` by default.
 
 ## Project Structure
+
 - `components/` – Reusable UI components
 - `services/` – Business logic and data services
 - `styles/` – Theme and global style definitions
@@ -62,6 +65,7 @@ IdeaForge Local is a privacy-first, local-only ideation and project management t
 - Configuration: `jest.config.cjs`, `tsconfig.json`, `vite.config.ts`, etc.
 
 ## Development Workflow
+
 - **Start Dev Server:** `npm run dev`
 - **Build for Production:** `npm run build`
 - **Lint:** `npm run lint`
@@ -70,12 +74,15 @@ IdeaForge Local is a privacy-first, local-only ideation and project management t
 - **Test with Coverage:** `npm test -- --coverage`
 
 ## Continuous Integration
+
 A GitHub Actions workflow (`.github/workflows/ci.yml`) runs linting, formatting, and tests on every push to ensure code quality.
 
 ## Contributing
+
 Contributions are welcome! Please open an issue or pull request with your suggestions or improvements. See `CONTRIBUTING.md` for guidelines (if available).
 
 ## License
+
 Specify your license here (e.g., MIT, Apache 2.0).
 
 ---

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,2 +1,1 @@
-
 module.exports = 'test-file-stub';

--- a/components/BlueprintCard.tsx
+++ b/components/BlueprintCard.tsx
@@ -2,16 +2,23 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { motion, useMotionValue, useSpring, useTransform, Variants } from 'framer-motion';
 import { Project, Idea } from '../types';
-import Button from './Button'; 
-import { StarIcon, EyeIcon, DocumentTextIcon, PlusCircleIcon, TrashIcon, EyeSlashIcon } from './icons'; 
+import Button from './Button';
+import {
+  StarIcon,
+  EyeIcon,
+  DocumentTextIcon,
+  PlusCircleIcon,
+  TrashIcon,
+  EyeSlashIcon,
+} from './icons';
 
 interface BlueprintCardProps {
   item: Project | Idea;
   type: 'project' | 'idea';
   onSelect?: (item: Project | Idea) => void;
-  onQuickNewIdea?: (project: Project) => void; 
+  onQuickNewIdea?: (project: Project) => void;
   onDelete?: (item: Project | Idea) => void;
-  onToggleFavorite?: (projectId: string) => void; 
+  onToggleFavorite?: (projectId: string) => void;
   className?: string;
 }
 
@@ -43,15 +50,26 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
   const mouseXSpring = useSpring(x, springConfig);
   const mouseYSpring = useSpring(y, springConfig);
 
-  const rotateX = useTransform(mouseYSpring, [-0.5, 0.5], prefersReducedMotion ? ['0deg', '0deg'] : ['7deg', '-7deg']); 
-  const rotateY = useTransform(mouseXSpring, [-0.5, 0.5], prefersReducedMotion ? ['0deg', '0deg'] : ['-7deg', '7deg']); 
+  const rotateX = useTransform(
+    mouseYSpring,
+    [-0.5, 0.5],
+    prefersReducedMotion ? ['0deg', '0deg'] : ['7deg', '-7deg']
+  );
+  const rotateY = useTransform(
+    mouseXSpring,
+    [-0.5, 0.5],
+    prefersReducedMotion ? ['0deg', '0deg'] : ['-7deg', '7deg']
+  );
 
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    if (prefersReducedMotion || !cardRef.current) return;
-    const rect = cardRef.current.getBoundingClientRect();
-    x.set((e.clientX - rect.left) / rect.width - 0.5);
-    y.set((e.clientY - rect.top) / rect.height - 0.5);
-  }, [prefersReducedMotion]);
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (prefersReducedMotion || !cardRef.current) return;
+      const rect = cardRef.current.getBoundingClientRect();
+      x.set((e.clientX - rect.left) / rect.width - 0.5);
+      y.set((e.clientY - rect.top) / rect.height - 0.5);
+    },
+    [prefersReducedMotion]
+  );
 
   const handleMouseLeave = useCallback(() => {
     if (prefersReducedMotion) return;
@@ -60,11 +78,11 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
   }, [prefersReducedMotion]);
 
   const handleFlip = (e?: React.MouseEvent) => {
-    e?.stopPropagation(); 
-    if (type === 'idea') { 
+    e?.stopPropagation();
+    if (type === 'idea') {
       setIsFlipped(!isFlipped);
     } else if (onSelect) {
-      onSelect(item); 
+      onSelect(item);
     }
   };
 
@@ -72,45 +90,67 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
   const idea = type === 'idea' ? (item as Idea) : null;
 
   const cardMotionVariants: Variants = {
-    initial: { scale: 1, boxShadow: 'var(--shadow-card)'}, // Use CSS var
-    hover: prefersReducedMotion ? {} : { 
-      scale: 1.03, 
-      boxShadow: 'var(--shadow-card-hover)', // Use CSS var
-      transition: { type: 'spring', stiffness: 200, damping: 15 }
-    },
+    initial: { scale: 1, boxShadow: 'var(--shadow-card)' }, // Use CSS var
+    hover: prefersReducedMotion
+      ? {}
+      : {
+          scale: 1.03,
+          boxShadow: 'var(--shadow-card-hover)', // Use CSS var
+          transition: { type: 'spring', stiffness: 200, damping: 15 },
+        },
     glitchInitial: { opacity: 0, filter: 'blur(2px) contrast(0.9)' },
-    glitchAnimate: { 
-      opacity: 1, 
+    glitchAnimate: {
+      opacity: 1,
       filter: 'blur(0px) contrast(1)',
-      transition: { duration: 0.3, delay: Math.random() * 0.15 + 0.05 } 
+      transition: { duration: 0.3, delay: Math.random() * 0.15 + 0.05 },
     },
   };
-  
+
   const flipContainerVariants: Variants = {
     initial: { rotateY: 0 },
     flipped: { rotateY: 180 },
   };
 
-  const titleText = type === 'project' && project ? project.name : type === 'idea' && idea ? idea.title : '';
-  const cardBG = project?.isFavorite ? 'bg-theme-bg-accent shadow-glow-accent-md' : 'bg-theme-bg-secondary';
+  const titleText =
+    type === 'project' && project ? project.name : type === 'idea' && idea ? idea.title : '';
+  const cardBG = project?.isFavorite
+    ? 'bg-theme-bg-accent shadow-glow-accent-md'
+    : 'bg-theme-bg-secondary';
 
   const renderFront = () => (
     <motion.div
       className={`absolute inset-0 w-full h-full p-space-sm sm:p-space-xs_md rounded-card flex flex-col justify-between backface-hidden border border-theme-border-primary/70 ${cardBG} transition-colors duration-300`}
-      style={{ WebkitBackfaceVisibility: 'hidden', MozBackfaceVisibility: 'hidden', backfaceVisibility: 'hidden' }}
+      style={{
+        WebkitBackfaceVisibility: 'hidden',
+        MozBackfaceVisibility: 'hidden',
+        backfaceVisibility: 'hidden',
+      }}
     >
       <div>
         <div className="flex justify-between items-start mb-space-xs">
-          <div className="flex items-center min-w-0"> 
-            {(project?.logo || idea?.logo) ? (
-              <img src={project?.logo || idea?.logo} alt={`${titleText} logo`} className="w-8 h-8 object-cover rounded-sm mr-space-xs flex-shrink-0 border border-theme-accent-primary/30" />
+          <div className="flex items-center min-w-0">
+            {project?.logo || idea?.logo ? (
+              <img
+                src={project?.logo || idea?.logo}
+                alt={`${titleText} logo`}
+                className="w-8 h-8 object-cover rounded-sm mr-space-xs flex-shrink-0 border border-theme-accent-primary/30"
+              />
             ) : (
               <DocumentTextIcon className="w-8 h-8 text-theme-accent-primary/60 mr-space-xs flex-shrink-0" />
             )}
-            <h3 
+            <h3
               className="text-lg sm:text-xl font-display font-semibold text-theme-accent-primary truncate cursor-pointer hover:text-opacity-80 transition-opacity"
-              onClick={(e) => { e.stopPropagation(); if(onSelect) onSelect(item); }}
-              title={type === 'project' && project ? `Open Constellation: ${project.name}` : type === 'idea' && idea ? `Edit Blueprint: ${idea.title}` : ''}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (onSelect) onSelect(item);
+              }}
+              title={
+                type === 'project' && project
+                  ? `Open Constellation: ${project.name}`
+                  : type === 'idea' && idea
+                    ? `Edit Blueprint: ${idea.title}`
+                    : ''
+              }
             >
               {titleText}
             </h3>
@@ -119,9 +159,12 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
             <Button
               variant="icon"
               size="sm"
-              onClick={(e) => { e.stopPropagation(); onToggleFavorite(project.id); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleFavorite(project.id);
+              }}
               className={`!p-1 ml-space-xs ${project.isFavorite ? 'text-theme-accent-primary shadow-glow-accent-sm' : 'text-theme-text-secondary hover:text-theme-accent-primary'}`}
-              aria-label={project.isFavorite ? "Unmark as favorite" : "Mark as favorite"}
+              aria-label={project.isFavorite ? 'Unmark as favorite' : 'Mark as favorite'}
               prefersReducedMotion={prefersReducedMotion}
             >
               <StarIcon className="w-5 h-5" isFilled={project.isFavorite} />
@@ -129,8 +172,11 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
           )}
         </div>
         {idea && (
-          <p className="text-xs sm:text-sm text-theme-text-secondary mb-1 line-clamp-2" title={idea.problemSolved}>
-            Challenge: {idea.problemSolved || "Not specified"}
+          <p
+            className="text-xs sm:text-sm text-theme-text-secondary mb-1 line-clamp-2"
+            title={idea.problemSolved}
+          >
+            Challenge: {idea.problemSolved || 'Not specified'}
           </p>
         )}
         {project && (
@@ -141,27 +187,64 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
       </div>
       <div className="mt-auto pt-space-xs">
         <p className="text-xs text-theme-text-secondary/70">
-          {type === 'project' ? 'Ignited' : 'Forged'}: {new Date(type === 'project' ? item.createdAt : (item as Idea).updatedAt).toLocaleDateString()}
+          {type === 'project' ? 'Ignited' : 'Forged'}:{' '}
+          {new Date(
+            type === 'project' ? item.createdAt : (item as Idea).updatedAt
+          ).toLocaleDateString()}
         </p>
         <div className="flex items-center justify-end space-x-space-xs mt-space-xs">
           {type === 'idea' && (
-            <Button variant="icon" size="sm" onClick={handleFlip} title={isFlipped ? "Close Preview" : "Preview Blueprint"} prefersReducedMotion={prefersReducedMotion}>
-              {isFlipped ? <EyeSlashIcon className="w-5 h-5"/> : <EyeIcon className="w-5 h-5"/>}
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={handleFlip}
+              title={isFlipped ? 'Close Preview' : 'Preview Blueprint'}
+              prefersReducedMotion={prefersReducedMotion}
+            >
+              {isFlipped ? <EyeSlashIcon className="w-5 h-5" /> : <EyeIcon className="w-5 h-5" />}
             </Button>
           )}
           {project && onQuickNewIdea && (
-             <Button variant="icon" size="sm" onClick={(e) => {e.stopPropagation(); onQuickNewIdea(project);}} title="New Blueprint in Constellation" prefersReducedMotion={prefersReducedMotion}>
-              <PlusCircleIcon className="w-5 h-5"/>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onQuickNewIdea(project);
+              }}
+              title="New Blueprint in Constellation"
+              prefersReducedMotion={prefersReducedMotion}
+            >
+              <PlusCircleIcon className="w-5 h-5" />
             </Button>
           )}
           {onSelect && (
-            <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); onSelect(item); }} title={type === 'project' ? 'Open Constellation' : 'Edit Blueprint'} prefersReducedMotion={prefersReducedMotion}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelect(item);
+              }}
+              title={type === 'project' ? 'Open Constellation' : 'Edit Blueprint'}
+              prefersReducedMotion={prefersReducedMotion}
+            >
               {type === 'project' ? 'Open' : 'Edit'}
             </Button>
           )}
           {onDelete && (
-             <Button variant="icon" size="sm" onClick={(e) => { e.stopPropagation(); onDelete(item); }} title={`Disassemble ${type}`} className="text-status-error hover:bg-status-error/10" prefersReducedMotion={prefersReducedMotion}>
-              <TrashIcon className="w-5 h-5"/>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(item);
+              }}
+              title={`Disassemble ${type}`}
+              className="text-status-error hover:bg-status-error/10"
+              prefersReducedMotion={prefersReducedMotion}
+            >
+              <TrashIcon className="w-5 h-5" />
             </Button>
           )}
         </div>
@@ -169,34 +252,60 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
     </motion.div>
   );
 
-  const renderBack = () => (
+  const renderBack = () =>
     idea && (
-    <motion.div
-      className="absolute inset-0 w-full h-full bg-theme-bg-accent p-space-sm sm:p-space-xs_md rounded-card flex flex-col justify-between backface-hidden border border-theme-border-primary shadow-card overflow-y-auto custom-scrollbar"
-      style={{ transform: 'rotateY(180deg)', WebkitBackfaceVisibility: 'hidden', MozBackfaceVisibility: 'hidden', backfaceVisibility: 'hidden' }}
-    >
-      <div className="space-y-space-xs text-theme-text-primary font-body"> 
-        <div className="flex items-center border-b border-theme-accent-primary/30 pb-space-xxs mb-space-xs">
-          {idea.logo && <img src={idea.logo} alt="Blueprint logo" className="w-10 h-10 object-cover rounded-sm mr-space-xs border border-theme-accent-primary/20"/>}
-          <h4 className="text-md font-display font-semibold text-theme-accent-primary">Preview: {idea.title}</h4>
+      <motion.div
+        className="absolute inset-0 w-full h-full bg-theme-bg-accent p-space-sm sm:p-space-xs_md rounded-card flex flex-col justify-between backface-hidden border border-theme-border-primary shadow-card overflow-y-auto custom-scrollbar"
+        style={{
+          transform: 'rotateY(180deg)',
+          WebkitBackfaceVisibility: 'hidden',
+          MozBackfaceVisibility: 'hidden',
+          backfaceVisibility: 'hidden',
+        }}
+      >
+        <div className="space-y-space-xs text-theme-text-primary font-body">
+          <div className="flex items-center border-b border-theme-accent-primary/30 pb-space-xxs mb-space-xs">
+            {idea.logo && (
+              <img
+                src={idea.logo}
+                alt="Blueprint logo"
+                className="w-10 h-10 object-cover rounded-sm mr-space-xs border border-theme-accent-primary/20"
+              />
+            )}
+            <h4 className="text-md font-display font-semibold text-theme-accent-primary">
+              Preview: {idea.title}
+            </h4>
+          </div>
+          <div>
+            <h5 className="text-xs font-semibold text-theme-text-secondary">Problem:</h5>
+            <p className="text-xs whitespace-pre-wrap line-clamp-3 custom-scrollbar">
+              {idea.problemSolved || 'N/A'}
+            </p>
+          </div>
+          <div>
+            <h5 className="text-xs font-semibold text-theme-text-secondary">Solution:</h5>
+            <p className="text-xs whitespace-pre-wrap line-clamp-3 custom-scrollbar">
+              {idea.coreSolution || 'N/A'}
+            </p>
+          </div>
+          <div>
+            <h5 className="text-xs font-semibold text-theme-text-secondary">Key Features:</h5>
+            <p className="text-xs whitespace-pre-wrap line-clamp-3 custom-scrollbar">
+              {idea.keyFeatures || 'N/A'}
+            </p>
+          </div>
         </div>
-        <div>
-          <h5 className="text-xs font-semibold text-theme-text-secondary">Problem:</h5>
-          <p className="text-xs whitespace-pre-wrap line-clamp-3 custom-scrollbar">{idea.problemSolved || "N/A"}</p>
-        </div>
-        <div>
-          <h5 className="text-xs font-semibold text-theme-text-secondary">Solution:</h5>
-          <p className="text-xs whitespace-pre-wrap line-clamp-3 custom-scrollbar">{idea.coreSolution || "N/A"}</p>
-        </div>
-        <div>
-          <h5 className="text-xs font-semibold text-theme-text-secondary">Key Features:</h5>
-          <p className="text-xs whitespace-pre-wrap line-clamp-3 custom-scrollbar">{idea.keyFeatures || "N/A"}</p>
-        </div>
-      </div>
-      <Button variant="outline" size="sm" onClick={handleFlip} className="mt-auto self-end" prefersReducedMotion={prefersReducedMotion}>Close Preview</Button>
-    </motion.div>
-    )
-  );
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleFlip}
+          className="mt-auto self-end"
+          prefersReducedMotion={prefersReducedMotion}
+        >
+          Close Preview
+        </Button>
+      </motion.div>
+    );
 
   return (
     <motion.div
@@ -204,25 +313,36 @@ const BlueprintCard: React.FC<BlueprintCardProps> = ({
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
       style={{
-        rotateX: prefersReducedMotion ? 0 : rotateX, 
-        rotateY: prefersReducedMotion ? 0 : rotateY, 
-        transformStyle: 'preserve-3d', 
-        perspective: '1000px', 
+        rotateX: prefersReducedMotion ? 0 : rotateX,
+        rotateY: prefersReducedMotion ? 0 : rotateY,
+        transformStyle: 'preserve-3d',
+        perspective: '1000px',
       }}
       className={`relative w-full aspect-[3/2] sm:aspect-[4/2.5] min-h-[190px] sm:min-h-[210px] cursor-default ${className || ''}`}
-      variants={cardMotionVariants} 
-      initial="glitchInitial" 
-      animate="glitchAnimate" 
-      whileHover={prefersReducedMotion ? undefined : "hover"} 
-      onClick={type === 'project' && !prefersReducedMotion ? (e) => { e.stopPropagation(); if (onSelect) onSelect(item); } : undefined} 
-      layout 
+      variants={cardMotionVariants}
+      initial="glitchInitial"
+      animate="glitchAnimate"
+      whileHover={prefersReducedMotion ? undefined : 'hover'}
+      onClick={
+        type === 'project' && !prefersReducedMotion
+          ? (e) => {
+              e.stopPropagation();
+              if (onSelect) onSelect(item);
+            }
+          : undefined
+      }
+      layout
     >
       <motion.div
         className="relative w-full h-full"
         style={{ transformStyle: 'preserve-3d' }}
         variants={flipContainerVariants}
         animate={isFlipped ? 'flipped' : 'initial'}
-        transition={prefersReducedMotion ? { duration: 0.01 } : { type: 'spring', stiffness: 120, damping: 18 }}
+        transition={
+          prefersReducedMotion
+            ? { duration: 0.01 }
+            : { type: 'spring', stiffness: 120, damping: 18 }
+        }
       >
         {renderFront()}
         {type === 'idea' && renderBack()}

--- a/components/Button.test.tsx
+++ b/components/Button.test.tsx
@@ -61,7 +61,11 @@ describe('Button Component', () => {
 
   test('does not call onClick handler when disabled and clicked', () => {
     const handleClick = jest.fn();
-    render(<Button onClick={handleClick} disabled>Disabled</Button>);
+    render(
+      <Button onClick={handleClick} disabled>
+        Disabled
+      </Button>
+    );
     fireEvent.click(screen.getByText(/disabled/i));
     expect(handleClick).not.toHaveBeenCalled();
   });

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -65,19 +65,21 @@ const Button: React.FC<ButtonProps> = ({
   };
 
   const sizeStyles = {
-    xs: "px-2.5 py-1 text-xs", // Smaller padding and text
-    sm: "px-3 py-1.5 text-sm",
-    md: "px-5 py-2 text-sm", // Default Tailwind text-sm is 0.875rem
-    lg: "px-6 py-2.5 text-base",
-    xl: "px-7 py-3 text-lg", // Larger padding and text
+    xs: 'px-2.5 py-1 text-xs', // Smaller padding and text
+    sm: 'px-3 py-1.5 text-sm',
+    md: 'px-5 py-2 text-sm', // Default Tailwind text-sm is 0.875rem
+    lg: 'px-6 py-2.5 text-base',
+    xl: 'px-7 py-3 text-lg', // Larger padding and text
   };
-  
+
   const currentSizeStyles = variant === 'icon' ? '!p-2' : sizeStyles[size]; // Override for icon
 
-  const motionProps = prefersReducedMotion ? {} : {
-    whileHover: { scale: (variant === 'icon' || variant === 'ghost') ? 1.1 : 1.05 },
-    whileTap: { scale: 0.95 },
-  };
+  const motionProps = prefersReducedMotion
+    ? {}
+    : {
+        whileHover: { scale: variant === 'icon' || variant === 'ghost' ? 1.1 : 1.05 },
+        whileTap: { scale: 0.95 },
+      };
 
   const actualDisabled = disabled || isLoading;
 
@@ -91,21 +93,40 @@ const Button: React.FC<ButtonProps> = ({
       {...(props as any)} // Cast the rest of the props to 'any' to bypass TS conflict with onDrag
     >
       {isLoading ? (
-        <svg 
-            className="animate-spin h-5 w-5 text-currentColor" 
-            xmlns="http://www.w3.org/2000/svg" 
-            fill="none" 
-            viewBox="0 0 24 24"
-            aria-hidden="true"
+        <svg
+          className="animate-spin h-5 w-5 text-currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
         >
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
         </svg>
       ) : (
         <>
-          {leftIcon && <span className={`inline-block ${children ? "mr-2" : ""}`} aria-hidden="true">{leftIcon}</span>}
+          {leftIcon && (
+            <span className={`inline-block ${children ? 'mr-2' : ''}`} aria-hidden="true">
+              {leftIcon}
+            </span>
+          )}
           {children}
-          {rightIcon && <span className={`inline-block ${children ? "ml-2" : ""}`} aria-hidden="true">{rightIcon}</span>}
+          {rightIcon && (
+            <span className={`inline-block ${children ? 'ml-2' : ''}`} aria-hidden="true">
+              {rightIcon}
+            </span>
+          )}
         </>
       )}
     </motion.button>

--- a/components/ContactPanel.tsx
+++ b/components/ContactPanel.tsx
@@ -11,7 +11,8 @@ interface ContactPanelProps {
   onClose: () => void;
 }
 
-const panelVariants: Variants = { // Explicitly typed with Variants
+const panelVariants: Variants = {
+  // Explicitly typed with Variants
   hidden: { y: '100%', opacity: 0.8 },
   visible: { y: '0%', opacity: 1, transition: { type: 'spring', stiffness: 100, damping: 20 } },
   exit: { y: '100%', opacity: 0, transition: { ease: 'anticipate', duration: 0.4 } },
@@ -29,19 +30,22 @@ const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose }) => {
     setIsSubmitting(true);
     setSubmitStatus(null);
     // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 1500));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     // Replace with actual form submission logic (e.g., to Formspree, Netlify Forms, or backend)
     console.log('Form submitted:', { name, email, message });
     setIsSubmitting(false);
-    if (Math.random() > 0.1) { // Simulate mostly success
-        setSubmitStatus('success');
-        setName(''); setEmail(''); setMessage('');
-        setTimeout(() => {
-            setSubmitStatus(null);
-            onClose(); 
-        }, 3000);
+    if (Math.random() > 0.1) {
+      // Simulate mostly success
+      setSubmitStatus('success');
+      setName('');
+      setEmail('');
+      setMessage('');
+      setTimeout(() => {
+        setSubmitStatus(null);
+        onClose();
+      }, 3000);
     } else {
-        setSubmitStatus('error');
+      setSubmitStatus('error');
     }
   };
 
@@ -64,13 +68,22 @@ const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose }) => {
             onClick={(e) => e.stopPropagation()} // Prevent closing when clicking panel content
           >
             <div className="flex justify-between items-center mb-6">
-              <h2 className="text-2xl font-sans font-bold text-theme-accent-primary">Send a Transmission</h2>
+              <h2 className="text-2xl font-sans font-bold text-theme-accent-primary">
+                Send a Transmission
+              </h2>
               <div className="help-tooltip-wrapper">
-                <Button variant="icon" onClick={onClose} aria-label="Close Contact Panel" className="help-tooltip-icon">
+                <Button
+                  variant="icon"
+                  onClick={onClose}
+                  aria-label="Close Contact Panel"
+                  className="help-tooltip-icon"
+                >
                   <XMarkIcon className="w-6 h-6 text-theme-text-secondary hover:text-theme-accent-primary" />
                 </Button>
                 {/* Tooltip text styled globally and uses theme vars */}
-                <span className="help-tooltip-text !text-xs !min-w-[100px] !max-w-[150px] !text-center">Seal Transmission Channel</span> 
+                <span className="help-tooltip-text !text-xs !min-w-[100px] !max-w-[150px] !text-center">
+                  Seal Transmission Channel
+                </span>
               </div>
             </div>
 
@@ -81,7 +94,8 @@ const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose }) => {
             )}
             {submitStatus === 'error' && (
               <div className="text-center p-4 bg-status-error/20 text-status-error rounded-md mb-4">
-                Cosmic static disrupted your signal. Please try re-transmitting or use an alternate frequency.
+                Cosmic static disrupted your signal. Please try re-transmitting or use an alternate
+                frequency.
               </div>
             )}
 
@@ -119,7 +133,7 @@ const ContactPanel: React.FC<ContactPanelProps> = ({ isOpen, onClose }) => {
                   variant="default" // This variant uses theme-accent-primary
                   isLoading={isSubmitting}
                   disabled={isSubmitting}
-                  leftIcon={<PaperAirplaneIcon className="w-5 h-5"/>}
+                  leftIcon={<PaperAirplaneIcon className="w-5 h-5" />}
                 >
                   {isSubmitting ? 'Sending Signal...' : 'Transmit Message'}
                 </Button>

--- a/components/CosmicForgeLogo.tsx
+++ b/components/CosmicForgeLogo.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { motion } from 'framer-motion';
 
 const CosmicForgeLogo: React.FC = () => (
-    <motion.div
-      className="flex justify-center items-center pt-12 pb-6 z-10"
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.8, ease: 'easeOut' }}
-    >
-      <img
-        src="https://cdn.jsdelivr.net/gh/agattone96/ideaforge@34f45d8f52fb64c5f5cc8711954ece369f964c10/ideaforgelogo.png"
-        alt="IdeaForge Logo"
-        className="w-full max-w-[340px] h-auto drop-shadow-[0_0_18px_#f72585]"
-        draggable={false}
-      />
-    </motion.div>
-  );
+  <motion.div
+    className="flex justify-center items-center pt-12 pb-6 z-10"
+    initial={{ opacity: 0, scale: 0.95 }}
+    animate={{ opacity: 1, scale: 1 }}
+    transition={{ duration: 0.8, ease: 'easeOut' }}
+  >
+    <img
+      src="https://cdn.jsdelivr.net/gh/agattone96/ideaforge@34f45d8f52fb64c5f5cc8711954ece369f964c10/ideaforgelogo.png"
+      alt="IdeaForge Logo"
+      className="w-full max-w-[340px] h-auto drop-shadow-[0_0_18px_#f72585]"
+      draggable={false}
+    />
+  </motion.div>
+);
 
 export default CosmicForgeLogo;

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -26,7 +26,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // You can also log the error to an error reporting service
-    console.error("Uncaught error:", error, errorInfo);
+    console.error('Uncaught error:', error, errorInfo);
     this.setState({ error, errorInfo });
   }
 
@@ -42,19 +42,23 @@ class ErrorBoundary extends Component<Props, State> {
           <ExclamationTriangleIcon className="w-16 h-16 text-error mb-6" />
           <h1 className="text-3xl font-bold text-amber mb-4">Cosmic Anomaly Detected</h1>
           <p className="text-lg text-off-white-dim mb-2 text-center max-w-md">
-            A quantum fluctuation has occurred in the IdeaForge. Apologies for this brief journey into the unexpected.
+            A quantum fluctuation has occurred in the IdeaForge. Apologies for this brief journey
+            into the unexpected.
           </p>
           <p className="text-sm text-off-white-dim mb-8 text-center max-w-md">
-            Try re-igniting the forge (reload). If the anomaly persists, consult the star-charts (console) or consider a full data dissolution if corruption is suspected.
+            Try re-igniting the forge (reload). If the anomaly persists, consult the star-charts
+            (console) or consider a full data dissolution if corruption is suspected.
           </p>
-          
+
           <Button onClick={this.handleReload} variant="default" size="lg">
             Reload Application
           </Button>
 
           {process.env.NODE_ENV === 'development' && this.state.error && (
             <details className="mt-8 p-4 bg-charcoal-light rounded-lg text-left max-w-xl w-full overflow-auto">
-              <summary className="cursor-pointer text-amber hover:text-amber-light">Anomaly Report (Dev Sector)</summary>
+              <summary className="cursor-pointer text-amber hover:text-amber-light">
+                Anomaly Report (Dev Sector)
+              </summary>
               <pre className="mt-2 text-xs text-off-white whitespace-pre-wrap">
                 {this.state.error.toString()}
                 {this.state.errorInfo && this.state.errorInfo.componentStack}

--- a/components/GlowCard.tsx
+++ b/components/GlowCard.tsx
@@ -21,19 +21,21 @@ const GlowCard: React.FC<GlowCardProps> = ({
   padding = 'p-6',
   prefersReducedMotion = false,
 }) => {
-  const cardVariants: Variants = prefersReducedMotion ? {
-    initial: { opacity: 0 },
-    animate: { opacity: 1, transition: { duration: 0.1 } },
-    hover: {},
-  } : {
-    initial: { opacity: 0, y: 10 },
-    animate: { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' } },
-    hover: { 
-      scale: 1.02, 
-      boxShadow: `0 0 15px ${glowColor || 'var(--color-glow-primary)'}, 0 0 25px ${glowColor || 'var(--color-glow-secondary)'}`,
-      transition: { duration: 0.3, ease: 'circOut' }
-    },
-  };
+  const cardVariants: Variants = prefersReducedMotion
+    ? {
+        initial: { opacity: 0 },
+        animate: { opacity: 1, transition: { duration: 0.1 } },
+        hover: {},
+      }
+    : {
+        initial: { opacity: 0, y: 10 },
+        animate: { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' } },
+        hover: {
+          scale: 1.02,
+          boxShadow: `0 0 15px ${glowColor || 'var(--color-glow-primary)'}, 0 0 25px ${glowColor || 'var(--color-glow-secondary)'}`,
+          transition: { duration: 0.3, ease: 'circOut' },
+        },
+      };
 
   const defaultGlowClasses = glowColor ? '' : 'shadow-glow-accent-sm hover:shadow-glow-accent-md';
 
@@ -51,10 +53,14 @@ const GlowCard: React.FC<GlowCardProps> = ({
       variants={cardVariants}
       initial="initial"
       animate="animate"
-      whileHover={hoverEffect && !prefersReducedMotion ? "hover" : undefined}
-      style={hoverEffect && glowColor && !prefersReducedMotion ? {
-        // Custom glow if glowColor is provided directly, otherwise Tailwind handles it
-      } : {}}
+      whileHover={hoverEffect && !prefersReducedMotion ? 'hover' : undefined}
+      style={
+        hoverEffect && glowColor && !prefersReducedMotion
+          ? {
+              // Custom glow if glowColor is provided directly, otherwise Tailwind handles it
+            }
+          : {}
+      }
     >
       {children}
     </motion.div>

--- a/components/IdeaEditor.test.tsx
+++ b/components/IdeaEditor.test.tsx
@@ -1,5 +1,3 @@
-
-
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -12,7 +10,7 @@ import * as fileService from '../services/fileService'; // Adjust path
 
 // Mock services
 jest.mock('../services/localStorageService', () => ({
-  isAiEnabled: jest.fn<() => boolean>(() => true), 
+  isAiEnabled: jest.fn<() => boolean>(() => true),
   generateIdeaBoilerplate: jest.fn<() => Promise<localStorageService.IdeaBoilerplate>>(), // Use namespace if ambiguous
   summarizeIdea: jest.fn<() => Promise<string>>(),
   addIdeaToProject: jest.fn<() => void>(),
@@ -21,31 +19,61 @@ jest.mock('../services/localStorageService', () => ({
 }));
 jest.mock('../services/fileService', () => ({
   exportIdea: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
-  readFileAsText: jest.fn<() => Promise<string>>().mockResolvedValue("mock text content"),
-  readFileAsBase64: jest.fn<() => Promise<string>>().mockResolvedValue("data:image/png;base64,mockbase64"),
+  readFileAsText: jest.fn<() => Promise<string>>().mockResolvedValue('mock text content'),
+  readFileAsBase64: jest
+    .fn<() => Promise<string>>()
+    .mockResolvedValue('data:image/png;base64,mockbase64'),
   sanitizeFilename: jest.fn((name: string) => name.replace(/[^a-zA-Z0-9.]/g, '_')),
   base64ToBlob: jest.fn().mockReturnValue(new Blob()),
 }));
-jest.mock('./Button', () => ({ children, ...props }: any) => <button {...props}>{children}</button>);
-jest.mock('./TextInput', () => ({ label, name, value, onChange, helpText, ...props }: any) => <label>{label}{helpText && <span title={helpText}>?</span>}<input name={name} value={value} onChange={onChange} {...props} /></label>);
-jest.mock('./TextArea', () => ({ label, name, value, onChange, helpText, ...props }: any) => <label>{label}{helpText && <span title={helpText}>?</span>}<textarea name={name} value={value} onChange={onChange} {...props} /></label>);
-
+jest.mock('./Button', () => ({ children, ...props }: any) => (
+  <button {...props}>{children}</button>
+));
+jest.mock('./TextInput', () => ({ label, name, value, onChange, helpText, ...props }: any) => (
+  <label>
+    {label}
+    {helpText && <span title={helpText}>?</span>}
+    <input name={name} value={value} onChange={onChange} {...props} />
+  </label>
+));
+jest.mock('./TextArea', () => ({ label, name, value, onChange, helpText, ...props }: any) => (
+  <label>
+    {label}
+    {helpText && <span title={helpText}>?</span>}
+    <textarea name={name} value={value} onChange={onChange} {...props} />
+  </label>
+));
 
 const mockAddNotification = jest.fn();
 const mockOnSave = jest.fn();
 const mockOnCancel = jest.fn();
 
 const sampleProject: Project = {
-  id: 'proj1', name: 'Test Project', ideas: [], attachments: [], createdAt: '2023-01-01T00:00:00.000Z',
+  id: 'proj1',
+  name: 'Test Project',
+  ideas: [],
+  attachments: [],
+  createdAt: '2023-01-01T00:00:00.000Z',
 };
 const sampleIdeaToEdit: Idea = {
-  id: 'idea1', title: 'Editable Idea', problemSolved: 'A problem', coreSolution: 'A solution', keyFeatures: 'Feature 1', targetAudience: 'Users', inspirationNotes: 'Some notes', attachments: [], createdAt: '2023-01-01T00:00:00.000Z', updatedAt: '2023-01-01T00:00:00.000Z',
+  id: 'idea1',
+  title: 'Editable Idea',
+  problemSolved: 'A problem',
+  coreSolution: 'A solution',
+  keyFeatures: 'Feature 1',
+  targetAudience: 'Users',
+  inspirationNotes: 'Some notes',
+  attachments: [],
+  createdAt: '2023-01-01T00:00:00.000Z',
+  updatedAt: '2023-01-01T00:00:00.000Z',
 };
 
 describe('IdeaEditor Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (localStorageService.getProjectById as jest.Mock<() => Project | undefined>).mockReturnValue(sampleProject); 
+    (localStorageService.getProjectById as jest.Mock<() => Project | undefined>).mockReturnValue(
+      sampleProject
+    );
   });
 
   const renderEditor = (ideaToEdit: Idea | null) => {
@@ -82,34 +110,47 @@ describe('IdeaEditor Component', () => {
 
   test('calls onSave with correct data for a new idea', () => {
     renderEditor(null);
-    fireEvent.change(screen.getByLabelText(/Blueprint Title\*/i), { target: { value: 'Final Title' } });
+    fireEvent.change(screen.getByLabelText(/Blueprint Title\*/i), {
+      target: { value: 'Final Title' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /Save Blueprint/i }));
-    
+
     expect(localStorageService.addIdeaToProject).toHaveBeenCalledWith(
       sampleProject.id,
       expect.objectContaining({ title: 'Final Title' })
     );
-    expect(mockAddNotification).toHaveBeenCalledWith('Blueprint "Final Title" forged and filed.', 'success');
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'Blueprint "Final Title" forged and filed.',
+      'success'
+    );
     expect(mockOnSave).toHaveBeenCalled();
   });
 
   test('calls onSave with correct data for an existing idea', () => {
     renderEditor(sampleIdeaToEdit);
-    fireEvent.change(screen.getByLabelText(/Problem Solved/i), { target: { value: 'Updated Problem' } });
+    fireEvent.change(screen.getByLabelText(/Problem Solved/i), {
+      target: { value: 'Updated Problem' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /Save Blueprint/i }));
 
     expect(localStorageService.updateIdeaInProject).toHaveBeenCalledWith(
       sampleProject.id,
       expect.objectContaining({ id: sampleIdeaToEdit.id, problemSolved: 'Updated Problem' })
     );
-    expect(mockAddNotification).toHaveBeenCalledWith(`Blueprint "${sampleIdeaToEdit.title}" forged and filed.`, 'success');
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      `Blueprint "${sampleIdeaToEdit.title}" forged and filed.`,
+      'success'
+    );
     expect(mockOnSave).toHaveBeenCalled();
   });
 
   test('shows error if title is empty on save', () => {
     renderEditor(null);
     fireEvent.click(screen.getByRole('button', { name: /Save Blueprint/i }));
-    expect(mockAddNotification).toHaveBeenCalledWith('A blueprint needs a name to echo in the cosmos. Title, please!', 'error');
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'A blueprint needs a name to echo in the cosmos. Title, please!',
+      'error'
+    );
     expect(localStorageService.addIdeaToProject).not.toHaveBeenCalled();
   });
 
@@ -122,18 +163,30 @@ describe('IdeaEditor Component', () => {
   test('calls exportIdea when "Export Blueprint" button is clicked for an existing idea', async () => {
     renderEditor(sampleIdeaToEdit);
     await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: /Export Blueprint/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Export Blueprint/i }));
     });
-    expect(fileService.exportIdea).toHaveBeenCalledWith(expect.objectContaining({ id: sampleIdeaToEdit.id }));
-    expect(mockAddNotification).toHaveBeenCalledWith(`Transmitting Blueprint "${sampleIdeaToEdit.title}" beyond the forge...`, 'success');
+    expect(fileService.exportIdea).toHaveBeenCalledWith(
+      expect.objectContaining({ id: sampleIdeaToEdit.id })
+    );
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      `Transmitting Blueprint "${sampleIdeaToEdit.title}" beyond the forge...`,
+      'success'
+    );
   });
 
   test('AI boilerplate generation button interaction', async () => {
-    (localStorageService.generateIdeaBoilerplate as jest.Mock<() => Promise<IdeaBoilerplate>>).mockResolvedValueOnce({
-      problemSolved: 'Generated Problem', coreSolution: 'Generated Solution', keyFeatures: '', targetAudience: ''
+    (
+      localStorageService.generateIdeaBoilerplate as jest.Mock<() => Promise<IdeaBoilerplate>>
+    ).mockResolvedValueOnce({
+      problemSolved: 'Generated Problem',
+      coreSolution: 'Generated Solution',
+      keyFeatures: '',
+      targetAudience: '',
     });
     renderEditor(null);
-    fireEvent.change(screen.getByLabelText(/Blueprint Title\*/i), { target: { value: 'AI Test Title' } });
+    fireEvent.change(screen.getByLabelText(/Blueprint Title\*/i), {
+      target: { value: 'AI Test Title' },
+    });
     // The button is an icon button, target it by title or a more specific role if possible
     fireEvent.click(screen.getByTitle(/Summon Cosmic Muse/i));
 
@@ -141,29 +194,43 @@ describe('IdeaEditor Component', () => {
       expect(localStorageService.generateIdeaBoilerplate).toHaveBeenCalledWith('AI Test Title');
     });
     expect(screen.getByLabelText(/Problem Solved/i)).toHaveValue('Generated Problem');
-    expect(mockAddNotification).toHaveBeenCalledWith('The Cosmic Muse has whispered some starting points!', 'success');
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'The Cosmic Muse has whispered some starting points!',
+      'success'
+    );
   });
-  
+
   test('AI summarize notes button interaction', async () => {
-    (localStorageService.summarizeIdea as jest.Mock<() => Promise<string>>).mockResolvedValueOnce("AI Summary of notes.");
+    (localStorageService.summarizeIdea as jest.Mock<() => Promise<string>>).mockResolvedValueOnce(
+      'AI Summary of notes.'
+    );
     renderEditor(null);
     const notesTextArea = screen.getByPlaceholderText(/Sketch your constellations here/i);
     fireEvent.change(notesTextArea, { target: { value: 'Some notes to summarize.' } });
     fireEvent.click(screen.getByTitle(/Consult AI Oracle/i));
 
     await waitFor(() => {
-        expect(localStorageService.summarizeIdea).toHaveBeenCalledWith(expect.objectContaining({
-            inspirationNotes: 'Some notes to summarize.'
-        }));
+      expect(localStorageService.summarizeIdea).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inspirationNotes: 'Some notes to summarize.',
+        })
+      );
     });
-    expect(notesTextArea).toHaveValue('Some notes to summarize.\n\n--- AI Oracle\'s Distillation ---\nAI Summary of notes.');
-    expect(mockAddNotification).toHaveBeenCalledWith('The AI Oracle has distilled your thoughts!', 'success');
+    expect(notesTextArea).toHaveValue(
+      "Some notes to summarize.\n\n--- AI Oracle's Distillation ---\nAI Summary of notes."
+    );
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'The AI Oracle has distilled your thoughts!',
+      'success'
+    );
   });
 
   test('handles file drop and processes attachments', async () => {
     renderEditor(null);
-    const dropzone = screen.getByPlaceholderText(/Sketch your constellations here/i).closest('div[class*="md:col-span-3"]');
-    if (!dropzone) throw new Error("Dropzone not found");
+    const dropzone = screen
+      .getByPlaceholderText(/Sketch your constellations here/i)
+      .closest('div[class*="md:col-span-3"]');
+    if (!dropzone) throw new Error('Dropzone not found');
 
     const mockFile = new File(['mock content'], 'test.png', { type: 'image/png' });
     const dataTransfer = { files: [mockFile], types: ['Files'] };
@@ -172,11 +239,10 @@ describe('IdeaEditor Component', () => {
       fireEvent.dragOver(dropzone, { dataTransfer }); // Simulate drag over
       fireEvent.drop(dropzone, { dataTransfer });
     });
-    
+
     await waitFor(() => {
       expect(fileService.readFileAsBase64).toHaveBeenCalledWith(mockFile);
     });
     expect(mockAddNotification).toHaveBeenCalledWith('Materializing your artifacts...', 'info');
   });
-  
 });

--- a/components/IdeaEditor.tsx
+++ b/components/IdeaEditor.tsx
@@ -1,4 +1,3 @@
-
 // components/IdeaEditor.tsx (Blueprint Canvas)
 import React, { useState, useEffect, useCallback, useRef, ChangeEvent } from 'react';
 import { motion } from 'framer-motion';
@@ -8,9 +7,27 @@ import Button from './Button';
 import TextInput from './TextInput';
 import TextArea from './TextArea';
 import * as localStorageService from '../services/localStorageService';
-import { exportIdea, readFileAsText, readFileAsBase64, sanitizeFilename, base64ToBlob } from '../services/fileService';
+import {
+  exportIdea,
+  readFileAsText,
+  readFileAsBase64,
+  sanitizeFilename,
+  base64ToBlob,
+} from '../services/fileService';
 import { exportViewAsPdfZine } from '../utils/zineExporter'; // Import Zine Exporter
-import { SparklesIcon, DocumentArrowDownIcon, DocumentTextIcon, PhotoIcon, DocumentIcon, TrashIcon, ArrowLeftIcon, PlusCircleIcon, ArrowDownTrayIcon, ArrowUpTrayIcon, DocumentChartBarIcon } from './icons';
+import {
+  SparklesIcon,
+  DocumentArrowDownIcon,
+  DocumentTextIcon,
+  PhotoIcon,
+  DocumentIcon,
+  TrashIcon,
+  ArrowLeftIcon,
+  PlusCircleIcon,
+  ArrowDownTrayIcon,
+  ArrowUpTrayIcon,
+  DocumentChartBarIcon,
+} from './icons';
 
 interface IdeaEditorProps {
   project: Project;
@@ -21,16 +38,31 @@ interface IdeaEditorProps {
 }
 
 const emptyIdea: Omit<Idea, 'id' | 'createdAt' | 'updatedAt'> = {
-  title: '', problemSolved: '', coreSolution: '', keyFeatures: '', targetAudience: '', inspirationNotes: '', attachments: [], logo: undefined,
+  title: '',
+  problemSolved: '',
+  coreSolution: '',
+  keyFeatures: '',
+  targetAudience: '',
+  inspirationNotes: '',
+  attachments: [],
+  logo: undefined,
 };
 
 const MAX_BLUEPRINT_LOGO_SIZE_MB = 1;
 const ALLOWED_BLUEPRINT_LOGO_TYPES = ['image/png', 'image/jpeg', 'image/svg+xml'];
 const IDEA_EDITOR_CONTENT_ID = 'idea-editor-content-area'; // ID for PDF capture
 
-
-const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, onCancel, addNotification }) => {
-  const [idea, setIdea] = useState<Omit<Idea, 'id' | 'createdAt' | 'updatedAt' > & Partial<Pick<Idea, 'id' | 'createdAt' | 'updatedAt'>>>(emptyIdea);
+const IdeaEditor: React.FC<IdeaEditorProps> = ({
+  project,
+  ideaToEdit,
+  onSave,
+  onCancel,
+  addNotification,
+}) => {
+  const [idea, setIdea] = useState<
+    Omit<Idea, 'id' | 'createdAt' | 'updatedAt'> &
+      Partial<Pick<Idea, 'id' | 'createdAt' | 'updatedAt'>>
+  >(emptyIdea);
   const [isDragging, setIsDragging] = useState(false);
   const [isGeneratingBoilerplate, setIsGeneratingBoilerplate] = useState(false);
   const [isSummarizing, setIsSummarizing] = useState(false);
@@ -41,14 +73,17 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
   const editorContentRef = useRef<HTMLDivElement>(null); // Ref for the main content area
 
   const fieldHelp = {
-    title: "The designation for your blueprint. Let it resonate across the cosmos.",
-    logo: "Optional: A unique sigil for this specific blueprint, a miniature star.",
-    problemSolved: "What cosmic imbalance or earthly void does your blueprint seek to rectify?",
-    coreSolution: "Describe the heart of your idea, its central star and guiding light.",
-    keyFeatures: "Chart the key constellations of functionality. Use '-' or '*' for each star point.",
-    targetAudience: "For whom does this cosmic creation shine? Who are its destined travelers?",
-    inspirationNotes: "Your canvas for cosmic cartography. Drag & drop images, text files, or entire nebulae (ZIPs).",
-    attachments: "Attach relevant files like mockups, research documents, or assets to this blueprint."
+    title: 'The designation for your blueprint. Let it resonate across the cosmos.',
+    logo: 'Optional: A unique sigil for this specific blueprint, a miniature star.',
+    problemSolved: 'What cosmic imbalance or earthly void does your blueprint seek to rectify?',
+    coreSolution: 'Describe the heart of your idea, its central star and guiding light.',
+    keyFeatures:
+      "Chart the key constellations of functionality. Use '-' or '*' for each star point.",
+    targetAudience: 'For whom does this cosmic creation shine? Who are its destined travelers?',
+    inspirationNotes:
+      'Your canvas for cosmic cartography. Drag & drop images, text files, or entire nebulae (ZIPs).',
+    attachments:
+      'Attach relevant files like mockups, research documents, or assets to this blueprint.',
   };
 
   useEffect(() => {
@@ -56,7 +91,7 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
   }, [ideaToEdit]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setIdea(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    setIdea((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
   const handleSave = () => {
@@ -65,22 +100,37 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
       return;
     }
     const now = new Date().toISOString();
-    const savedIdea: Idea = idea.id 
-      ? { ...idea, updatedAt: now } as Idea // idea already includes 'logo' if set
-      : { ...idea, id: crypto.randomUUID(), createdAt: now, updatedAt: now } as Idea; // new idea includes 'logo'
-    
+    const savedIdea: Idea = idea.id
+      ? ({ ...idea, updatedAt: now } as Idea) // idea already includes 'logo' if set
+      : ({ ...idea, id: crypto.randomUUID(), createdAt: now, updatedAt: now } as Idea); // new idea includes 'logo'
+
     if (idea.id) localStorageService.updateIdeaInProject(project.id, savedIdea);
     else localStorageService.addIdeaToProject(project.id, savedIdea);
-    
+
     const updatedProject = localStorageService.getProjectById(project.id);
     if (updatedProject) onSave(updatedProject);
     addNotification(`Blueprint "${savedIdea.title}" forged and filed.`, 'success'); // Updated
   };
 
   const handleExport = async () => {
-    if (!idea.id) { addNotification('Forge the blueprint first to give it form.', 'info'); return; } // Updated
-    try { await exportIdea(idea as Idea); addNotification(`Transmitting Blueprint "${idea.title}" (Markdown) beyond the forge...`, 'success'); } // Clarified Markdown export
-    catch (error) { addNotification(`Transmission error. Blueprint "${idea.title}" remains in the forge.`, 'error'); console.error(error); } // Updated
+    if (!idea.id) {
+      addNotification('Forge the blueprint first to give it form.', 'info');
+      return;
+    } // Updated
+    try {
+      await exportIdea(idea as Idea);
+      addNotification(
+        `Transmitting Blueprint "${idea.title}" (Markdown) beyond the forge...`,
+        'success'
+      );
+    } catch (error) {
+      // Clarified Markdown export
+      addNotification(
+        `Transmission error. Blueprint "${idea.title}" remains in the forge.`,
+        'error'
+      );
+      console.error(error);
+    } // Updated
   };
 
   const handleExportZine = async () => {
@@ -89,11 +139,14 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
       return;
     }
     if (!editorContentRef.current) {
-        addNotification('Cannot capture blueprint content for Zine. DOM element not found.', 'error');
-        return;
+      addNotification('Cannot capture blueprint content for Zine. DOM element not found.', 'error');
+      return;
     }
     setIsExportingZine(true);
-    addNotification(`Preparing Blueprint Zine for "${idea.title}"... This may take a moment.`, 'info');
+    addNotification(
+      `Preparing Blueprint Zine for "${idea.title}"... This may take a moment.`,
+      'info'
+    );
     try {
       // The main motion.div already has IDEA_EDITOR_CONTENT_ID
       await exportViewAsPdfZine({
@@ -102,137 +155,211 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
       });
       addNotification(`Blueprint Zine for "${idea.title}" exported successfully.`, 'success');
     } catch (error) {
-      addNotification(`Failed to export Blueprint Zine: ${error instanceof Error ? error.message : String(error)}`, 'error');
+      addNotification(
+        `Failed to export Blueprint Zine: ${error instanceof Error ? error.message : String(error)}`,
+        'error'
+      );
       console.error(error);
     }
     setIsExportingZine(false);
   };
 
-
   const handleGenerateBoilerplate = async () => {
-    if (!idea.title.trim()) { addNotification('Give your idea a name, and the Cosmic Muse shall sing.', 'info'); return; } // Updated
-    if (!aiEnabled) { addNotification('The Cosmic Muse is slumbering. Awaken it with your API key.', 'error'); return; } // Updated
+    if (!idea.title.trim()) {
+      addNotification('Give your idea a name, and the Cosmic Muse shall sing.', 'info');
+      return;
+    } // Updated
+    if (!aiEnabled) {
+      addNotification('The Cosmic Muse is slumbering. Awaken it with your API key.', 'error');
+      return;
+    } // Updated
     setIsGeneratingBoilerplate(true);
     try {
       const boilerplate = await localStorageService.generateIdeaBoilerplate(idea.title);
-      setIdea(prev => ({ ...prev, ...boilerplate }));
+      setIdea((prev) => ({ ...prev, ...boilerplate }));
       addNotification('The Cosmic Muse has whispered some starting points!', 'success'); // Updated
-    } catch (e) { addNotification(`Cosmic Interference: The AI Muse is a bit fuzzy. ${e instanceof Error ? e.message : String(e)}`, 'error'); } // Updated
+    } catch (e) {
+      addNotification(
+        `Cosmic Interference: The AI Muse is a bit fuzzy. ${e instanceof Error ? e.message : String(e)}`,
+        'error'
+      );
+    } // Updated
     setIsGeneratingBoilerplate(false);
   };
 
   const handleSummarizeNotes = async () => {
-    if (!idea.inspirationNotes?.trim() && !idea.coreSolution?.trim()) { addNotification('Share your whispers or solutions, and the AI Oracle shall find their essence.', 'info'); return; } // Updated
-    if (!aiEnabled) { addNotification('The Cosmic Muse is slumbering. Awaken it with your API key.', 'error'); return; } // Updated
+    if (!idea.inspirationNotes?.trim() && !idea.coreSolution?.trim()) {
+      addNotification(
+        'Share your whispers or solutions, and the AI Oracle shall find their essence.',
+        'info'
+      );
+      return;
+    } // Updated
+    if (!aiEnabled) {
+      addNotification('The Cosmic Muse is slumbering. Awaken it with your API key.', 'error');
+      return;
+    } // Updated
     setIsSummarizing(true);
     try {
-      const summaryContent = { title: idea.title, problemSolved: idea.problemSolved, coreSolution: idea.coreSolution, keyFeatures: idea.keyFeatures, targetAudience: idea.targetAudience, inspirationNotes: idea.inspirationNotes };
+      const summaryContent = {
+        title: idea.title,
+        problemSolved: idea.problemSolved,
+        coreSolution: idea.coreSolution,
+        keyFeatures: idea.keyFeatures,
+        targetAudience: idea.targetAudience,
+        inspirationNotes: idea.inspirationNotes,
+      };
       const summary = await localStorageService.summarizeIdea(summaryContent);
-      setIdea(prev => ({ ...prev, inspirationNotes: `${prev.inspirationNotes || ''}\n\n--- AI Oracle's Distillation ---\n${summary}` })); // Updated summary separator
+      setIdea((prev) => ({
+        ...prev,
+        inspirationNotes: `${prev.inspirationNotes || ''}\n\n--- AI Oracle's Distillation ---\n${summary}`,
+      })); // Updated summary separator
       addNotification('The AI Oracle has distilled your thoughts!', 'success'); // Updated
-    } catch (e) { addNotification(`Cosmic Interference: The AI Muse is a bit fuzzy. ${e instanceof Error ? e.message : String(e)}`, 'error'); } // Updated
+    } catch (e) {
+      addNotification(
+        `Cosmic Interference: The AI Muse is a bit fuzzy. ${e instanceof Error ? e.message : String(e)}`,
+        'error'
+      );
+    } // Updated
     setIsSummarizing(false);
   };
 
   const processFile = useCallback(async (file: File): Promise<Attachment | null> => {
-    const common = { id: crypto.randomUUID(), name: sanitizeFilename(file.name), mimeType: file.type, size: file.size };
-    if (file.type.startsWith('image/')) return { ...common, type: 'image', content: await readFileAsBase64(file) };
-    if (file.type === 'text/plain' || file.type === 'text/markdown') return { ...common, type: 'text', content: await readFileAsText(file) };
+    const common = {
+      id: crypto.randomUUID(),
+      name: sanitizeFilename(file.name),
+      mimeType: file.type,
+      size: file.size,
+    };
+    if (file.type.startsWith('image/'))
+      return { ...common, type: 'image', content: await readFileAsBase64(file) };
+    if (file.type === 'text/plain' || file.type === 'text/markdown')
+      return { ...common, type: 'text', content: await readFileAsText(file) };
     return { ...common, type: 'other', content: await readFileAsBase64(file) };
   }, []);
-  
-  const addProcessedAttachments = useCallback((processedAttachments: Attachment[], notesUpdateFromFile?: string) => {
-    setIdea(prev => {
+
+  const addProcessedAttachments = useCallback(
+    (processedAttachments: Attachment[], notesUpdateFromFile?: string) => {
+      setIdea((prev) => {
         let newInspirationNotes = prev.inspirationNotes || '';
         if (notesUpdateFromFile) {
-            newInspirationNotes += notesUpdateFromFile;
+          newInspirationNotes += notesUpdateFromFile;
         }
-        
-        processedAttachments.forEach(att => {
-            if (att.type === 'image') {
-                newInspirationNotes += `\n![${att.name}](_attachments/${att.name})`;
-            }
+
+        processedAttachments.forEach((att) => {
+          if (att.type === 'image') {
+            newInspirationNotes += `\n![${att.name}](_attachments/${att.name})`;
+          }
         });
 
-        return { 
-            ...prev, 
-            inspirationNotes: newInspirationNotes, 
-            attachments: [...prev.attachments, ...processedAttachments] 
+        return {
+          ...prev,
+          inspirationNotes: newInspirationNotes,
+          attachments: [...prev.attachments, ...processedAttachments],
         };
-    });
-  }, []);
+      });
+    },
+    []
+  );
 
-  const handleFileUpload = useCallback(async (files: FileList | File[] | null) => {
-    if (!files || files.length === 0) return;
-    addNotification('Materializing your artifacts...', 'info');
-    const newAttachmentsBatch: Attachment[] = [];
-    let aggregatedNotesUpdate = '';
+  const handleFileUpload = useCallback(
+    async (files: FileList | File[] | null) => {
+      if (!files || files.length === 0) return;
+      addNotification('Materializing your artifacts...', 'info');
+      const newAttachmentsBatch: Attachment[] = [];
+      let aggregatedNotesUpdate = '';
 
-    for (const file of Array.from(files)) {
-      if (file.type === 'application/zip') {
-        try { 
-          const zip = await JSZip.loadAsync(file);
-          const zipFileEntries = Object.values(zip.files).filter((f:any) => !f.dir);
-          const currentZipAttachments: Attachment[] = [];
-          for (const entry of zipFileEntries) {
-            const entryFile = new File([await (entry as any).async('blob')], (entry as any).name, {type: (await (entry as any).async('blob')).type});
-            const attachment = await processFile(entryFile);
-            if (attachment) {
-                 if (attachment.type === 'text') aggregatedNotesUpdate += `\n\n--- Appended from ${attachment.name} (in ${file.name}) ---\n${attachment.content}`;
-                 currentZipAttachments.push(attachment);
+      for (const file of Array.from(files)) {
+        if (file.type === 'application/zip') {
+          try {
+            const zip = await JSZip.loadAsync(file);
+            const zipFileEntries = Object.values(zip.files).filter((f: any) => !f.dir);
+            const currentZipAttachments: Attachment[] = [];
+            for (const entry of zipFileEntries) {
+              const entryFile = new File(
+                [await (entry as any).async('blob')],
+                (entry as any).name,
+                { type: (await (entry as any).async('blob')).type }
+              );
+              const attachment = await processFile(entryFile);
+              if (attachment) {
+                if (attachment.type === 'text')
+                  aggregatedNotesUpdate += `\n\n--- Appended from ${attachment.name} (in ${file.name}) ---\n${attachment.content}`;
+                currentZipAttachments.push(attachment);
+              }
             }
+            newAttachmentsBatch.push(...currentZipAttachments);
+            addNotification(
+              `Unpacked ${currentZipAttachments.length} artifacts from ${file.name}'s dimensional pouch.`,
+              'success'
+            );
+          } catch (err) {
+            console.error('ZIP Error:', err);
+            addNotification(
+              `Dimensional pouch for ${file.name} seems corrupted. Could not unpack.`,
+              'error'
+            );
           }
-          newAttachmentsBatch.push(...currentZipAttachments); 
-          addNotification(`Unpacked ${currentZipAttachments.length} artifacts from ${file.name}'s dimensional pouch.`, 'success');
-        } catch (err) { console.error("ZIP Error:", err); addNotification(`Dimensional pouch for ${file.name} seems corrupted. Could not unpack.`, 'error'); }
-      } else {
-        const attachment = await processFile(file);
-        if (attachment) {
-          if (attachment.type === 'text') aggregatedNotesUpdate += `\n\n--- Appended from ${attachment.name} ---\n${attachment.content}`;
-          newAttachmentsBatch.push(attachment);
+        } else {
+          const attachment = await processFile(file);
+          if (attachment) {
+            if (attachment.type === 'text')
+              aggregatedNotesUpdate += `\n\n--- Appended from ${attachment.name} ---\n${attachment.content}`;
+            newAttachmentsBatch.push(attachment);
+          }
         }
       }
-    }
-    
-    if (newAttachmentsBatch.length > 0) {
+
+      if (newAttachmentsBatch.length > 0) {
         addProcessedAttachments(newAttachmentsBatch, aggregatedNotesUpdate);
-    }
-    if (fileInputRef.current) fileInputRef.current.value = ""; 
-  }, [addNotification, processFile, addProcessedAttachments]);
+      }
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    },
+    [addNotification, processFile, addProcessedAttachments]
+  );
 
-
-  const handleDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault(); e.stopPropagation(); setIsDragging(false);
-    await handleFileUpload(e.dataTransfer.files);
-  }, [handleFileUpload]);
-
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      await handleFileUpload(e.dataTransfer.files);
+    },
+    [handleFileUpload]
+  );
 
   const removeAttachment = (id: string) => {
-    const attachmentToRemove = idea.attachments.find(att => att.id === id);
-    setIdea(prev => {
-        const updatedAttachments = prev.attachments.filter(att => att.id !== id);
-        let updatedNotes = prev.inspirationNotes || '';
-        if (attachmentToRemove && attachmentToRemove.type === 'image') {
-            const markdownLinkRegex = new RegExp(`\\n!\\[${attachmentToRemove.name}\\]\\(_attachments/${attachmentToRemove.name}\\)`, 'g');
-            updatedNotes = updatedNotes.replace(markdownLinkRegex, '');
-        }
-        return { ...prev, attachments: updatedAttachments, inspirationNotes: updatedNotes };
+    const attachmentToRemove = idea.attachments.find((att) => att.id === id);
+    setIdea((prev) => {
+      const updatedAttachments = prev.attachments.filter((att) => att.id !== id);
+      let updatedNotes = prev.inspirationNotes || '';
+      if (attachmentToRemove && attachmentToRemove.type === 'image') {
+        const markdownLinkRegex = new RegExp(
+          `\\n!\\[${attachmentToRemove.name}\\]\\(_attachments/${attachmentToRemove.name}\\)`,
+          'g'
+        );
+        updatedNotes = updatedNotes.replace(markdownLinkRegex, '');
+      }
+      return { ...prev, attachments: updatedAttachments, inspirationNotes: updatedNotes };
     });
   };
 
   const handleDownloadAttachment = (attachment: Attachment) => {
     try {
-        const blob = base64ToBlob(attachment.content, attachment.mimeType);
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = attachment.name;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(link.href);
-        addNotification(`Beaming down artifact "${attachment.name}"...`, 'info'); // Updated
+      const blob = base64ToBlob(attachment.content, attachment.mimeType);
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = attachment.name;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+      addNotification(`Beaming down artifact "${attachment.name}"...`, 'info'); // Updated
     } catch (error) {
-        addNotification(`Artifact "${attachment.name}" lost in transit: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error'); // Updated
+      addNotification(
+        `Artifact "${attachment.name}" lost in transit: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'error'
+      ); // Updated
     }
   };
 
@@ -241,38 +368,49 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
     if (!file) return;
 
     if (!ALLOWED_BLUEPRINT_LOGO_TYPES.includes(file.type)) {
-      addNotification(`This sigil's material isn't quite right for a blueprint. Use PNG, JPG, SVG. Got: ${file.type}`, 'error'); // Updated
+      addNotification(
+        `This sigil's material isn't quite right for a blueprint. Use PNG, JPG, SVG. Got: ${file.type}`,
+        'error'
+      ); // Updated
       return;
     }
     if (file.size > MAX_BLUEPRINT_LOGO_SIZE_MB * 1024 * 1024) {
-      addNotification(`Blueprint sigil too massive. Max: ${MAX_BLUEPRINT_LOGO_SIZE_MB}MB.`, 'error'); // Updated
+      addNotification(
+        `Blueprint sigil too massive. Max: ${MAX_BLUEPRINT_LOGO_SIZE_MB}MB.`,
+        'error'
+      ); // Updated
       return;
     }
     try {
       const base64Logo = await readFileAsBase64(file);
-      setIdea(prev => ({ ...prev, logo: base64Logo }));
-      addNotification('Blueprint sigil selected. Forge the blueprint to make it permanent.', 'info'); // Updated
+      setIdea((prev) => ({ ...prev, logo: base64Logo }));
+      addNotification(
+        'Blueprint sigil selected. Forge the blueprint to make it permanent.',
+        'info'
+      ); // Updated
     } catch (error) {
       addNotification('Blueprint sigil upload failed. The forge prefers other images.', 'error'); // Updated
     }
-    if (blueprintLogoInputRef.current) blueprintLogoInputRef.current.value = "";
+    if (blueprintLogoInputRef.current) blueprintLogoInputRef.current.value = '';
   };
 
   const handleRemoveBlueprintLogo = () => {
-     setIdea(prev => ({ ...prev, logo: undefined }));
-     addNotification('Blueprint sigil cleared. Forge the blueprint to update.', 'info'); // Updated
+    setIdea((prev) => ({ ...prev, logo: undefined }));
+    addNotification('Blueprint sigil cleared. Forge the blueprint to update.', 'info'); // Updated
   };
 
   const getFileIcon = (type: Attachment['type']) => {
-    if (type === 'image') return <PhotoIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
-    if (type === 'text') return <DocumentTextIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
+    if (type === 'image')
+      return <PhotoIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
+    if (type === 'text')
+      return <DocumentTextIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
     return <DocumentIcon className="w-5 h-5 text-theme-text-secondary mr-2 flex-shrink-0" />;
   };
 
   const isSaveDisabled = isGeneratingBoilerplate || isSummarizing || isExportingZine;
 
   return (
-    <motion.div 
+    <motion.div
       ref={editorContentRef} // Add ref here for PDF capture
       id={IDEA_EDITOR_CONTENT_ID} // Add static ID for PDF capture
       className="p-4 sm:p-6 md:p-8 w-full max-w-6xl mx-auto bg-theme-bg-secondary shadow-xl rounded-card border border-theme-border-primary font-body"
@@ -283,182 +421,332 @@ const IdeaEditor: React.FC<IdeaEditorProps> = ({ project, ideaToEdit, onSave, on
     >
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 sm:mb-8 pb-4 border-b border-theme-border-primary">
         <div className="w-full sm:w-auto mb-3 sm:mb-0">
-         <Button onClick={onCancel} variant="ghost" size="sm" className="mb-2" leftIcon={<ArrowLeftIcon className="w-5 h-5"/>}>
+          <Button
+            onClick={onCancel}
+            variant="ghost"
+            size="sm"
+            className="mb-2"
+            leftIcon={<ArrowLeftIcon className="w-5 h-5" />}
+          >
             Back to Constellation
           </Button>
-          <h2 className="text-2xl sm:text-3xl font-sans font-bold text-theme-accent-primary"> 
+          <h2 className="text-2xl sm:text-3xl font-sans font-bold text-theme-accent-primary">
             {idea.id ? 'Refine Blueprint' : 'Forge New Blueprint'}
           </h2>
         </div>
         <div className="flex space-x-2">
-            {idea.id && (
-                <>
-                <Button onClick={handleExport} variant="outline" size="md" leftIcon={<DocumentArrowDownIcon className="w-5 h-5"/>} disabled={isSaveDisabled}>
-                    Export (MD)
-                </Button>
-                <Button 
-                    onClick={handleExportZine} 
-                    variant="outline" 
-                    size="md" 
-                    leftIcon={<DocumentChartBarIcon className="w-5 h-5"/>}
-                    isLoading={isExportingZine}
-                    disabled={isSaveDisabled && !isExportingZine}
-                >
-                    Export Zine (PDF)
-                </Button>
-                </>
-            )}
+          {idea.id && (
+            <>
+              <Button
+                onClick={handleExport}
+                variant="outline"
+                size="md"
+                leftIcon={<DocumentArrowDownIcon className="w-5 h-5" />}
+                disabled={isSaveDisabled}
+              >
+                Export (MD)
+              </Button>
+              <Button
+                onClick={handleExportZine}
+                variant="outline"
+                size="md"
+                leftIcon={<DocumentChartBarIcon className="w-5 h-5" />}
+                isLoading={isExportingZine}
+                disabled={isSaveDisabled && !isExportingZine}
+              >
+                Export Zine (PDF)
+              </Button>
+            </>
+          )}
         </div>
       </div>
-      
-      <form onSubmit={(e) => { e.preventDefault(); handleSave(); }} className="grid grid-cols-1 md:grid-cols-5 gap-x-8 gap-y-6">
-        
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSave();
+        }}
+        className="grid grid-cols-1 md:grid-cols-5 gap-x-8 gap-y-6"
+      >
         <div className="md:col-span-2 space-y-5">
           <div className="flex items-start space-x-3">
             {/* Blueprint Logo Area */}
-            <div className="flex-shrink-0 mt-1.5 pt-5"> {/* pt-5 to align with label of TextInput */}
-                {idea.logo ? (
-                    <img src={idea.logo} alt="Blueprint logo" className="w-16 h-16 object-cover rounded-md border border-theme-accent-primary/30 shadow-sm"/>
-                ) : (
-                    <div className="w-16 h-16 bg-theme-bg-accent rounded-md flex items-center justify-center border border-theme-border-primary/50">
-                        <PhotoIcon className="w-8 h-8 text-theme-accent-primary/60"/>
-                    </div>
-                )}
-                <input 
-                    type="file" 
-                    accept={ALLOWED_BLUEPRINT_LOGO_TYPES.join(',')}
-                    ref={blueprintLogoInputRef} 
-                    onChange={handleBlueprintLogoUpload} 
-                    className="hidden"
-                    id="blueprint-logo-upload-input"
-                    aria-label="Upload blueprint logo"
+            <div className="flex-shrink-0 mt-1.5 pt-5">
+              {' '}
+              {/* pt-5 to align with label of TextInput */}
+              {idea.logo ? (
+                <img
+                  src={idea.logo}
+                  alt="Blueprint logo"
+                  className="w-16 h-16 object-cover rounded-md border border-theme-accent-primary/30 shadow-sm"
                 />
-                <div className="mt-1.5 space-y-1 text-center">
-                    <Button 
-                        type="button" 
-                        variant="ghost" 
-                        size="sm" 
-                        className="!text-xs !px-1.5 !py-0.5"
-                        onClick={() => blueprintLogoInputRef.current?.click()}
-                        title={idea.logo ? "Change blueprint sigil" : "Upload blueprint sigil"}
-                        disabled={isSaveDisabled}
-                    >
-                       <ArrowUpTrayIcon className="w-3 h-3 mr-1"/> {idea.logo ? 'Change' : 'Upload'}
-                    </Button>
-                    {idea.logo && (
-                        <Button 
-                            type="button" 
-                            variant="ghost" 
-                            size="sm" 
-                            className="!text-xs !px-1.5 !py-0.5 text-status-error/80 hover:text-status-error"
-                            onClick={handleRemoveBlueprintLogo}
-                            title="Remove blueprint sigil"
-                            disabled={isSaveDisabled}
-                        >
-                            <TrashIcon className="w-3 h-3 mr-1"/> Remove
-                        </Button>
-                    )}
+              ) : (
+                <div className="w-16 h-16 bg-theme-bg-accent rounded-md flex items-center justify-center border border-theme-border-primary/50">
+                  <PhotoIcon className="w-8 h-8 text-theme-accent-primary/60" />
                 </div>
+              )}
+              <input
+                type="file"
+                accept={ALLOWED_BLUEPRINT_LOGO_TYPES.join(',')}
+                ref={blueprintLogoInputRef}
+                onChange={handleBlueprintLogoUpload}
+                className="hidden"
+                id="blueprint-logo-upload-input"
+                aria-label="Upload blueprint logo"
+              />
+              <div className="mt-1.5 space-y-1 text-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="!text-xs !px-1.5 !py-0.5"
+                  onClick={() => blueprintLogoInputRef.current?.click()}
+                  title={idea.logo ? 'Change blueprint sigil' : 'Upload blueprint sigil'}
+                  disabled={isSaveDisabled}
+                >
+                  <ArrowUpTrayIcon className="w-3 h-3 mr-1" /> {idea.logo ? 'Change' : 'Upload'}
+                </Button>
+                {idea.logo && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="!text-xs !px-1.5 !py-0.5 text-status-error/80 hover:text-status-error"
+                    onClick={handleRemoveBlueprintLogo}
+                    title="Remove blueprint sigil"
+                    disabled={isSaveDisabled}
+                  >
+                    <TrashIcon className="w-3 h-3 mr-1" /> Remove
+                  </Button>
+                )}
+              </div>
             </div>
             {/* Title & AI Button */}
             <div className="flex-grow">
-                 <div className="flex items-end space-x-2">
-                    <TextInput name="title" label="Blueprint Title*" value={idea.title} onChange={handleChange} required helpText={fieldHelp.title} wrapperClassName="flex-grow" disabled={isSaveDisabled}/>
-                    {aiEnabled && <Button type="button" onClick={handleGenerateBoilerplate} variant="icon" size="md" className="self-end mb-0.5" disabled={isGeneratingBoilerplate || !idea.title.trim() || isSaveDisabled} title="Summon Cosmic Muse"><SparklesIcon className={`w-5 h-5 ${isGeneratingBoilerplate ? 'animate-spin' : ''}`}/></Button>}
-                 </div>
+              <div className="flex items-end space-x-2">
+                <TextInput
+                  name="title"
+                  label="Blueprint Title*"
+                  value={idea.title}
+                  onChange={handleChange}
+                  required
+                  helpText={fieldHelp.title}
+                  wrapperClassName="flex-grow"
+                  disabled={isSaveDisabled}
+                />
+                {aiEnabled && (
+                  <Button
+                    type="button"
+                    onClick={handleGenerateBoilerplate}
+                    variant="icon"
+                    size="md"
+                    className="self-end mb-0.5"
+                    disabled={isGeneratingBoilerplate || !idea.title.trim() || isSaveDisabled}
+                    title="Summon Cosmic Muse"
+                  >
+                    <SparklesIcon
+                      className={`w-5 h-5 ${isGeneratingBoilerplate ? 'animate-spin' : ''}`}
+                    />
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
 
-
-          <TextArea name="problemSolved" label="Problem Solved" value={idea.problemSolved} onChange={handleChange} helpText={fieldHelp.problemSolved} rows={3} disabled={isSaveDisabled}/>
-          <TextArea name="coreSolution" label="Core Solution" value={idea.coreSolution} onChange={handleChange} helpText={fieldHelp.coreSolution} rows={4} disabled={isSaveDisabled}/>
-          <TextArea name="keyFeatures" label="Key Features (List)" value={idea.keyFeatures} onChange={handleChange} helpText={fieldHelp.keyFeatures} rows={5} disabled={isSaveDisabled}/>
-          <TextArea name="targetAudience" label="Target Audience" value={idea.targetAudience} onChange={handleChange} helpText={fieldHelp.targetAudience} rows={3} disabled={isSaveDisabled}/>
+          <TextArea
+            name="problemSolved"
+            label="Problem Solved"
+            value={idea.problemSolved}
+            onChange={handleChange}
+            helpText={fieldHelp.problemSolved}
+            rows={3}
+            disabled={isSaveDisabled}
+          />
+          <TextArea
+            name="coreSolution"
+            label="Core Solution"
+            value={idea.coreSolution}
+            onChange={handleChange}
+            helpText={fieldHelp.coreSolution}
+            rows={4}
+            disabled={isSaveDisabled}
+          />
+          <TextArea
+            name="keyFeatures"
+            label="Key Features (List)"
+            value={idea.keyFeatures}
+            onChange={handleChange}
+            helpText={fieldHelp.keyFeatures}
+            rows={5}
+            disabled={isSaveDisabled}
+          />
+          <TextArea
+            name="targetAudience"
+            label="Target Audience"
+            value={idea.targetAudience}
+            onChange={handleChange}
+            helpText={fieldHelp.targetAudience}
+            rows={3}
+            disabled={isSaveDisabled}
+          />
         </div>
 
-        <div 
+        <div
           className="md:col-span-3 p-4 border-2 border-theme-border-primary rounded-lg transition-all flex flex-col min-h-[400px] md:min-h-full bg-theme-bg-accent/30"
-          onDrop={handleDrop} 
-          onDragOver={(e)=>{e.preventDefault(); e.stopPropagation(); if (!isSaveDisabled) setIsDragging(true);}} 
-          onDragLeave={(e)=>{e.preventDefault(); e.stopPropagation(); setIsDragging(false);}}
-          onDragEnd={(e)=>{e.preventDefault(); e.stopPropagation(); setIsDragging(false);}}
-          style={{ borderColor: isDragging ? 'var(--color-accent-primary)' : 'var(--color-border-primary)', borderWidth: '2px', borderStyle: isDragging? 'dashed' : 'solid'}}
+          onDrop={handleDrop}
+          onDragOver={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!isSaveDisabled) setIsDragging(true);
+          }}
+          onDragLeave={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsDragging(false);
+          }}
+          onDragEnd={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsDragging(false);
+          }}
+          style={{
+            borderColor: isDragging ? 'var(--color-accent-primary)' : 'var(--color-border-primary)',
+            borderWidth: '2px',
+            borderStyle: isDragging ? 'dashed' : 'solid',
+          }}
         >
           <div className="flex justify-between items-center mb-2">
-             <label className="block text-sm font-medium text-theme-text-secondary font-sans">Nebula Canvas & Star Charts</label>
-             {aiEnabled && <Button type="button" onClick={handleSummarizeNotes} variant="ghost" size="sm" className="!px-2 !py-1 text-xs" disabled={isSummarizing || (!idea.inspirationNotes?.trim() && !idea.coreSolution?.trim()) || isSaveDisabled} title="Consult AI Oracle"><SparklesIcon className={`w-4 h-4 mr-1 ${isSummarizing ? 'animate-spin' : ''}`}/>Summarize</Button>}
+            <label className="block text-sm font-medium text-theme-text-secondary font-sans">
+              Nebula Canvas & Star Charts
+            </label>
+            {aiEnabled && (
+              <Button
+                type="button"
+                onClick={handleSummarizeNotes}
+                variant="ghost"
+                size="sm"
+                className="!px-2 !py-1 text-xs"
+                disabled={
+                  isSummarizing ||
+                  (!idea.inspirationNotes?.trim() && !idea.coreSolution?.trim()) ||
+                  isSaveDisabled
+                }
+                title="Consult AI Oracle"
+              >
+                <SparklesIcon className={`w-4 h-4 mr-1 ${isSummarizing ? 'animate-spin' : ''}`} />
+                Summarize
+              </Button>
+            )}
           </div>
-          <TextArea 
-            name="inspirationNotes" 
-            value={idea.inspirationNotes} 
-            onChange={handleChange} 
-            placeholder="Sketch your constellations here, or drag & drop stardust (files)..." 
-            rows={10} 
-            className="bg-transparent border-none focus:ring-0 p-2 flex-grow w-full !text-theme-text-primary placeholder:!text-theme-text-secondary/70 resize-none custom-scrollbar" 
+          <TextArea
+            name="inspirationNotes"
+            value={idea.inspirationNotes}
+            onChange={handleChange}
+            placeholder="Sketch your constellations here, or drag & drop stardust (files)..."
+            rows={10}
+            className="bg-transparent border-none focus:ring-0 p-2 flex-grow w-full !text-theme-text-primary placeholder:!text-theme-text-secondary/70 resize-none custom-scrollbar"
             helpText={fieldHelp.inspirationNotes}
             disabled={isSaveDisabled}
           />
 
-           <div className="mt-4 border-t border-theme-border-primary pt-4">
-              <div className="flex justify-between items-center mb-2">
-                <h4 className="text-sm font-semibold text-theme-text-secondary font-sans flex items-center">
-                   Blueprint Artifacts <span className="ml-1.5 text-xs text-theme-accent-primary">({idea.attachments.length})</span>
-                </h4>
-                <input 
-                    type="file" 
-                    multiple 
-                    ref={fileInputRef} 
-                    onChange={(e) => handleFileUpload(e.target.files)} 
-                    className="hidden" 
-                    id="idea-file-upload-input"
-                    aria-label="Upload files to blueprint"
-                    disabled={isSaveDisabled}
-                />
-                <Button 
-                    type="button" 
-                    variant="outline" 
-                    size="sm" 
-                    onClick={() => fileInputRef.current?.click()}
-                    leftIcon={<PlusCircleIcon className="w-4 h-4"/>}
-                    disabled={isSaveDisabled}
-                >
-                    Add Attachment(s)
-                </Button>
-              </div>
-              {idea.attachments.length > 0 && (
-                <ul className="space-y-2 max-h-48 overflow-y-auto custom-scrollbar pr-1 mt-3">
-                  {idea.attachments.map(att => (
-                    <li key={att.id} className="flex items-center justify-between p-2 bg-theme-bg-accent/50 rounded-md hover:bg-theme-bg-accent transition-colors">
-                      <div className="flex items-center truncate mr-2">
-                        {getFileIcon(att.type)}
-                        <span className="text-sm text-theme-text-primary truncate" title={att.name}>{att.name}</span>
-                        <span className="text-xs text-theme-text-secondary ml-2 flex-shrink-0">({Math.round(att.size / 1024)} KB)</span>
-                      </div>
-                      <div className="flex space-x-1.5 flex-shrink-0">
-                        <Button type="button" variant="icon" size="sm" onClick={() => handleDownloadAttachment(att)} title="Download file" disabled={isSaveDisabled}>
-                          <ArrowDownTrayIcon className="w-4 h-4 text-theme-accent-primary"/>
-                        </Button>
-                        <Button type="button" variant="icon" size="sm" onClick={() => removeAttachment(att.id)} title="Delete file" className="text-status-error hover:bg-status-error/10" disabled={isSaveDisabled}>
-                          <TrashIcon className="w-4 h-4"/>
-                        </Button>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-               {idea.attachments.length === 0 && (
-                 <p className="text-xs text-theme-text-secondary text-center py-3">No artifacts tethered to this blueprint yet.</p>
-               )}
+          <div className="mt-4 border-t border-theme-border-primary pt-4">
+            <div className="flex justify-between items-center mb-2">
+              <h4 className="text-sm font-semibold text-theme-text-secondary font-sans flex items-center">
+                Blueprint Artifacts{' '}
+                <span className="ml-1.5 text-xs text-theme-accent-primary">
+                  ({idea.attachments.length})
+                </span>
+              </h4>
+              <input
+                type="file"
+                multiple
+                ref={fileInputRef}
+                onChange={(e) => handleFileUpload(e.target.files)}
+                className="hidden"
+                id="idea-file-upload-input"
+                aria-label="Upload files to blueprint"
+                disabled={isSaveDisabled}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                leftIcon={<PlusCircleIcon className="w-4 h-4" />}
+                disabled={isSaveDisabled}
+              >
+                Add Attachment(s)
+              </Button>
             </div>
-          
-          <p className={`mt-3 text-xs text-center ${isDragging ? 'text-theme-accent-primary font-semibold' : 'text-theme-text-secondary'}`}>
-            {isDragging ? 'Release to Anchor Artifacts to Canvas' : 'Drag artifacts to the Nebula Canvas, or use \'Add Attachment(s)\' to anchor them.'}
+            {idea.attachments.length > 0 && (
+              <ul className="space-y-2 max-h-48 overflow-y-auto custom-scrollbar pr-1 mt-3">
+                {idea.attachments.map((att) => (
+                  <li
+                    key={att.id}
+                    className="flex items-center justify-between p-2 bg-theme-bg-accent/50 rounded-md hover:bg-theme-bg-accent transition-colors"
+                  >
+                    <div className="flex items-center truncate mr-2">
+                      {getFileIcon(att.type)}
+                      <span className="text-sm text-theme-text-primary truncate" title={att.name}>
+                        {att.name}
+                      </span>
+                      <span className="text-xs text-theme-text-secondary ml-2 flex-shrink-0">
+                        ({Math.round(att.size / 1024)} KB)
+                      </span>
+                    </div>
+                    <div className="flex space-x-1.5 flex-shrink-0">
+                      <Button
+                        type="button"
+                        variant="icon"
+                        size="sm"
+                        onClick={() => handleDownloadAttachment(att)}
+                        title="Download file"
+                        disabled={isSaveDisabled}
+                      >
+                        <ArrowDownTrayIcon className="w-4 h-4 text-theme-accent-primary" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="icon"
+                        size="sm"
+                        onClick={() => removeAttachment(att.id)}
+                        title="Delete file"
+                        className="text-status-error hover:bg-status-error/10"
+                        disabled={isSaveDisabled}
+                      >
+                        <TrashIcon className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {idea.attachments.length === 0 && (
+              <p className="text-xs text-theme-text-secondary text-center py-3">
+                No artifacts tethered to this blueprint yet.
+              </p>
+            )}
+          </div>
+
+          <p
+            className={`mt-3 text-xs text-center ${isDragging ? 'text-theme-accent-primary font-semibold' : 'text-theme-text-secondary'}`}
+          >
+            {isDragging
+              ? 'Release to Anchor Artifacts to Canvas'
+              : "Drag artifacts to the Nebula Canvas, or use 'Add Attachment(s)' to anchor them."}
           </p>
         </div>
 
         <div className="md:col-span-5 flex justify-end space-x-3 sm:space-x-4 pt-6 border-t border-theme-border-primary mt-6">
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSaveDisabled}>Cancel</Button>
-          <Button type="submit" variant="default" isLoading={isGeneratingBoilerplate || isSummarizing || isExportingZine} disabled={isSaveDisabled}>
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSaveDisabled}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="default"
+            isLoading={isGeneratingBoilerplate || isSummarizing || isExportingZine}
+            disabled={isSaveDisabled}
+          >
             Forge Blueprint
           </Button>
         </div>

--- a/components/IdeaList.test.tsx
+++ b/components/IdeaList.test.tsx
@@ -1,5 +1,3 @@
-
-
 import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -10,20 +8,60 @@ import * as localStorageService from '../services/localStorageService'; // Adjus
 import * as fileService from '../services/fileService'; // Adjust path
 
 // Mock child components and services
-jest.mock('./BlueprintCard', () => ({ item, type, onSelect, onDelete }: { item: Project | Idea, type: string, onSelect: () => void, onDelete: () => void}) => (
-  <div data-testid={`blueprint-card-${item.id}`} onClick={onSelect}>
-    <span>{(item as Idea).title || (item as Project).name}</span>
-    <button onClick={onDelete} data-testid={`delete-btn-${item.id}`}>Delete Mock</button>
-  </div>
-));
-jest.mock('./Button', () => ({ children, ...props }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => <button {...props}>{children}</button>);
-jest.mock('./Modal', () => ({ isOpen, title, children, onClose }: {isOpen: boolean, title: string, children: React.ReactNode, onClose: () => void}) => isOpen ? (
-    <div data-testid="modal">
-        <h2>{title}</h2>
-        <div>{children}</div>
-        <button onClick={onClose}>Close Modal Mock</button>
-    </div>
-) : null);
+jest.mock(
+  './BlueprintCard',
+  () =>
+    ({
+      item,
+      type,
+      onSelect,
+      onDelete,
+    }: {
+      item: Project | Idea;
+      type: string;
+      onSelect: () => void;
+      onDelete: () => void;
+    }) => (
+      <div data-testid={`blueprint-card-${item.id}`} onClick={onSelect}>
+        <span>{(item as Idea).title || (item as Project).name}</span>
+        <button onClick={onDelete} data-testid={`delete-btn-${item.id}`}>
+          Delete Mock
+        </button>
+      </div>
+    )
+);
+jest.mock(
+  './Button',
+  () =>
+    ({
+      children,
+      ...props
+    }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+      <button {...props}>{children}</button>
+    )
+);
+jest.mock(
+  './Modal',
+  () =>
+    ({
+      isOpen,
+      title,
+      children,
+      onClose,
+    }: {
+      isOpen: boolean;
+      title: string;
+      children: React.ReactNode;
+      onClose: () => void;
+    }) =>
+      isOpen ? (
+        <div data-testid="modal">
+          <h2>{title}</h2>
+          <div>{children}</div>
+          <button onClick={onClose}>Close Modal Mock</button>
+        </div>
+      ) : null
+);
 
 jest.mock('../services/localStorageService');
 jest.mock('../services/fileService');
@@ -33,40 +71,100 @@ const mockOnCreateNewIdea = jest.fn();
 const mockOnBackToProjects = jest.fn();
 const mockRefreshProject = jest.fn();
 // Correct typing for mockAddNotification
-const mockAddNotification: jest.MockedFunction<(message: string, type: NotificationType['type']) => void> = jest.fn();
-
+const mockAddNotification: jest.MockedFunction<
+  (message: string, type: NotificationType['type']) => void
+> = jest.fn();
 
 const sampleIdea1: Idea = {
-  id: 'idea1', title: 'Eco Commute App', problemSolved: 'Carbon emissions', coreSolution: 'Gamified app', keyFeatures: 'Tracking, Rewards', targetAudience: 'Urban dwellers', inspirationNotes: '', attachments: [], createdAt: '2023-01-01T10:00:00Z', updatedAt: '2023-01-10T10:00:00Z',
+  id: 'idea1',
+  title: 'Eco Commute App',
+  problemSolved: 'Carbon emissions',
+  coreSolution: 'Gamified app',
+  keyFeatures: 'Tracking, Rewards',
+  targetAudience: 'Urban dwellers',
+  inspirationNotes: '',
+  attachments: [],
+  createdAt: '2023-01-01T10:00:00Z',
+  updatedAt: '2023-01-10T10:00:00Z',
 };
 const sampleIdea2: Idea = {
-  id: 'idea2', title: 'AI Recipe Generator', problemSolved: 'Food waste', coreSolution: 'AI generates recipes', keyFeatures: 'Ingredient input, Dietary filters', targetAudience: 'Home cooks', inspirationNotes: '', attachments: [], createdAt: '2023-01-05T10:00:00Z', updatedAt: '2023-01-05T10:00:00Z',
+  id: 'idea2',
+  title: 'AI Recipe Generator',
+  problemSolved: 'Food waste',
+  coreSolution: 'AI generates recipes',
+  keyFeatures: 'Ingredient input, Dietary filters',
+  targetAudience: 'Home cooks',
+  inspirationNotes: '',
+  attachments: [],
+  createdAt: '2023-01-05T10:00:00Z',
+  updatedAt: '2023-01-05T10:00:00Z',
 };
 const sampleProject: Project = {
-  id: 'proj1', name: 'Sustainable Living Tech', ideas: [sampleIdea1, sampleIdea2], attachments: [], createdAt: '2023-01-01T00:00:00Z',
+  id: 'proj1',
+  name: 'Sustainable Living Tech',
+  ideas: [sampleIdea1, sampleIdea2],
+  attachments: [],
+  createdAt: '2023-01-01T00:00:00Z',
 };
 const sampleProjectWithAttachments: Project = {
   ...sampleProject,
   attachments: [
-    { id: 'att1', name: 'Market_Research.pdf', type: 'other', mimeType: 'application/pdf', content: 'pdfcontent', size: 1000 },
-    { id: 'att2', name: 'Survey_Results.png', type: 'image', mimeType: 'image/png', content: 'pngcontent', size: 500 },
-  ]
+    {
+      id: 'att1',
+      name: 'Market_Research.pdf',
+      type: 'other',
+      mimeType: 'application/pdf',
+      content: 'pdfcontent',
+      size: 1000,
+    },
+    {
+      id: 'att2',
+      name: 'Survey_Results.png',
+      type: 'image',
+      mimeType: 'image/png',
+      content: 'pngcontent',
+      size: 500,
+    },
+  ],
 };
-
 
 describe('IdeaList Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Provide default mock implementations for services
-    (localStorageService.deleteIdeaFromProject as jest.MockedFunction<typeof localStorageService.deleteIdeaFromProject>).mockImplementation(() => {});
-    (localStorageService.updateProject as jest.MockedFunction<typeof localStorageService.updateProject>).mockImplementation(() => {});
-    (localStorageService.addAttachmentsToProject as jest.MockedFunction<typeof localStorageService.addAttachmentsToProject>).mockReturnValue(sampleProjectWithAttachments);
-    (localStorageService.deleteAttachmentFromProject as jest.MockedFunction<typeof localStorageService.deleteAttachmentFromProject>).mockReturnValue(sampleProject);
+    (
+      localStorageService.deleteIdeaFromProject as jest.MockedFunction<
+        typeof localStorageService.deleteIdeaFromProject
+      >
+    ).mockImplementation(() => {});
+    (
+      localStorageService.updateProject as jest.MockedFunction<
+        typeof localStorageService.updateProject
+      >
+    ).mockImplementation(() => {});
+    (
+      localStorageService.addAttachmentsToProject as jest.MockedFunction<
+        typeof localStorageService.addAttachmentsToProject
+      >
+    ).mockReturnValue(sampleProjectWithAttachments);
+    (
+      localStorageService.deleteAttachmentFromProject as jest.MockedFunction<
+        typeof localStorageService.deleteAttachmentFromProject
+      >
+    ).mockReturnValue(sampleProject);
 
-    (fileService.exportProjectAsZip as jest.MockedFunction<typeof fileService.exportProjectAsZip>).mockResolvedValue(undefined);
-    (fileService.readFileAsBase64 as jest.MockedFunction<typeof fileService.readFileAsBase64>).mockResolvedValue('data:image/png;base64,mocklogo');
-    (fileService.readFileAsText as jest.MockedFunction<typeof fileService.readFileAsText>).mockResolvedValue('mock text');
-    (fileService.base64ToBlob as jest.MockedFunction<typeof fileService.base64ToBlob>).mockReturnValue(new Blob(['mock blob content']));
+    (
+      fileService.exportProjectAsZip as jest.MockedFunction<typeof fileService.exportProjectAsZip>
+    ).mockResolvedValue(undefined);
+    (
+      fileService.readFileAsBase64 as jest.MockedFunction<typeof fileService.readFileAsBase64>
+    ).mockResolvedValue('data:image/png;base64,mocklogo');
+    (
+      fileService.readFileAsText as jest.MockedFunction<typeof fileService.readFileAsText>
+    ).mockResolvedValue('mock text');
+    (
+      fileService.base64ToBlob as jest.MockedFunction<typeof fileService.base64ToBlob>
+    ).mockReturnValue(new Blob(['mock blob content']));
 
     // Mock window.confirm
     window.confirm = jest.fn(() => true);
@@ -116,21 +214,27 @@ describe('IdeaList Component', () => {
     renderIdeaList(sampleProject);
     const deleteButton = screen.getByTestId(`delete-btn-${sampleIdea1.id}`); // Using the mock delete button
     await act(async () => {
-        fireEvent.click(deleteButton);
+      fireEvent.click(deleteButton);
     });
-    
+
     // Modal should appear
     expect(screen.getByTestId('modal')).toBeInTheDocument();
     expect(screen.getByText(`Disassemble Blueprint "${sampleIdea1.title}"?`)).toBeInTheDocument();
 
     // Click confirm delete in modal
-    const confirmDeleteButton = screen.getByRole('button', {name: /Delete Idea/i});
+    const confirmDeleteButton = screen.getByRole('button', { name: /Delete Idea/i });
     await act(async () => {
-        fireEvent.click(confirmDeleteButton);
+      fireEvent.click(confirmDeleteButton);
     });
 
-    expect(localStorageService.deleteIdeaFromProject).toHaveBeenCalledWith(sampleProject.id, sampleIdea1.id);
-    expect(mockAddNotification).toHaveBeenCalledWith(`Blueprint "${sampleIdea1.title}" disassembled.`, 'success');
+    expect(localStorageService.deleteIdeaFromProject).toHaveBeenCalledWith(
+      sampleProject.id,
+      sampleIdea1.id
+    );
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      `Blueprint "${sampleIdea1.title}" disassembled.`,
+      'success'
+    );
     expect(mockRefreshProject).toHaveBeenCalledWith(sampleProject.id);
   });
 
@@ -138,15 +242,18 @@ describe('IdeaList Component', () => {
     renderIdeaList(sampleProject);
     const exportButton = screen.getByRole('button', { name: /Export Project/i });
     await act(async () => {
-        fireEvent.click(exportButton);
+      fireEvent.click(exportButton);
     });
     expect(fileService.exportProjectAsZip).toHaveBeenCalledWith(sampleProject);
-    expect(mockAddNotification).toHaveBeenCalledWith(`Constellation "${sampleProject.name}" export initiated.`, 'success');
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      `Constellation "${sampleProject.name}" export initiated.`,
+      'success'
+    );
   });
 
   test('handles project logo upload and removal', async () => {
     renderIdeaList(sampleProject); // Initial render without logo
-    
+
     const uploadInput = screen.getByLabelText('Upload project logo') as HTMLInputElement;
 
     // Simulate file upload
@@ -156,52 +263,73 @@ describe('IdeaList Component', () => {
     });
 
     await waitFor(() => {
-        expect(fileService.readFileAsBase64).toHaveBeenCalledWith(mockFile);
+      expect(fileService.readFileAsBase64).toHaveBeenCalledWith(mockFile);
     });
-    expect(localStorageService.updateProject).toHaveBeenCalledWith(expect.objectContaining({ logo: 'data:image/png;base64,mocklogo' }));
-    expect(mockAddNotification).toHaveBeenCalledWith('Constellation sigil updated successfully.', 'success');
+    expect(localStorageService.updateProject).toHaveBeenCalledWith(
+      expect.objectContaining({ logo: 'data:image/png;base64,mocklogo' })
+    );
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'Constellation sigil updated successfully.',
+      'success'
+    );
     expect(mockRefreshProject).toHaveBeenCalledWith(sampleProject.id);
 
     // Simulate logo removal
     renderIdeaList({ ...sampleProject, logo: 'data:image/png;base64,mocklogo' }); // Re-render with a logo
-    
+
     const removeButton = screen.getByRole('button', { name: /Remove/i }); // Button text for removing logo
-     await act(async () => {
+    await act(async () => {
       fireEvent.click(removeButton);
     });
 
-    expect(localStorageService.updateProject).toHaveBeenCalledWith(expect.objectContaining({ logo: undefined }));
-    expect(mockAddNotification).toHaveBeenCalledWith('Constellation sigil has been cleared.', 'info');
+    expect(localStorageService.updateProject).toHaveBeenCalledWith(
+      expect.objectContaining({ logo: undefined })
+    );
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'Constellation sigil has been cleared.',
+      'info'
+    );
   });
 
   test('handles project attachment upload, download, and deletion', async () => {
     renderIdeaList(sampleProject); // Start with no attachments for upload test
 
     const fileUploadInput = screen.getByLabelText('Upload files to project') as HTMLInputElement;
-    const mockAttachmentFile = new File(['attachment content'], 'report.txt', { type: 'text/plain' });
+    const mockAttachmentFile = new File(['attachment content'], 'report.txt', {
+      type: 'text/plain',
+    });
 
     await act(async () => {
       fireEvent.change(fileUploadInput, { target: { files: [mockAttachmentFile] } });
     });
-    
+
     await waitFor(() => {
       expect(fileService.readFileAsText).toHaveBeenCalledWith(mockAttachmentFile);
     });
     expect(localStorageService.addAttachmentsToProject).toHaveBeenCalledWith(
       sampleProject.id,
       expect.arrayContaining([
-        expect.objectContaining({ name: 'report.txt', content: 'mock text' })
+        expect.objectContaining({ name: 'report.txt', content: 'mock text' }),
       ])
     );
-    expect(mockAddNotification).toHaveBeenCalledWith('1 support artifact(s) anchored to constellation.', 'success');
-
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      '1 support artifact(s) anchored to constellation.',
+      'success'
+    );
 
     // Test download and deletion (re-render with an attachment)
     const projectWithAttachmentForTest = {
-        ...sampleProject,
-        attachments: [
-            { id: 'att1', name: 'report.txt', type: 'text' as const, mimeType: 'text/plain', content: 'bW9jayB0ZXh0', size: 100 } // 'mock text' base64 encoded
-        ]
+      ...sampleProject,
+      attachments: [
+        {
+          id: 'att1',
+          name: 'report.txt',
+          type: 'text' as const,
+          mimeType: 'text/plain',
+          content: 'bW9jayB0ZXh0',
+          size: 100,
+        }, // 'mock text' base64 encoded
+      ],
     };
     renderIdeaList(projectWithAttachmentForTest);
 
@@ -209,16 +337,24 @@ describe('IdeaList Component', () => {
     const downloadButton = screen.getByTitle('Download file');
     fireEvent.click(downloadButton);
     expect(fileService.base64ToBlob).toHaveBeenCalledWith('bW9jayB0ZXh0', 'text/plain');
-    expect(mockAddNotification).toHaveBeenCalledWith('Beaming down artifact "report.txt"...', 'info');
+    expect(mockAddNotification).toHaveBeenCalledWith(
+      'Beaming down artifact "report.txt"...',
+      'info'
+    );
 
     // Delete
     const deleteAttachmentButton = screen.getByTitle('Delete file');
     fireEvent.click(deleteAttachmentButton); // This should trigger window.confirm
-    expect(window.confirm).toHaveBeenCalledWith("Are you sure you want to unlink this artifact from the constellation?");
-    expect(localStorageService.deleteAttachmentFromProject).toHaveBeenCalledWith(sampleProject.id, 'att1');
+    expect(window.confirm).toHaveBeenCalledWith(
+      'Are you sure you want to unlink this artifact from the constellation?'
+    );
+    expect(localStorageService.deleteAttachmentFromProject).toHaveBeenCalledWith(
+      sampleProject.id,
+      'att1'
+    );
     expect(mockAddNotification).toHaveBeenCalledWith('Constellation artifact unlinked.', 'info');
   });
-  
+
   test('sorts ideas based on selection', async () => {
     renderIdeaList(sampleProject);
     const sortSelect = screen.getByLabelText(/Arrange Blueprints by:/i) as HTMLSelectElement;
@@ -231,28 +367,32 @@ describe('IdeaList Component', () => {
     // Sort by Title (A-Z) -> idea2, idea1
     fireEvent.change(sortSelect, { target: { value: 'title_asc' } });
     await waitFor(() => {
-        ideaCards = screen.getAllByTestId(/blueprint-card-/);
-        expect(ideaCards[0]).toHaveTextContent(sampleIdea2.title); // AI Recipe Generator
-        expect(ideaCards[1]).toHaveTextContent(sampleIdea1.title); // Eco Commute App
+      ideaCards = screen.getAllByTestId(/blueprint-card-/);
+      expect(ideaCards[0]).toHaveTextContent(sampleIdea2.title); // AI Recipe Generator
+      expect(ideaCards[1]).toHaveTextContent(sampleIdea1.title); // Eco Commute App
     });
-    
+
     // Sort by Date Created (Newest) -> idea2, idea1
     fireEvent.change(sortSelect, { target: { value: 'createdAt_desc' } });
     await waitFor(() => {
-        ideaCards = screen.getAllByTestId(/blueprint-card-/);
-        expect(ideaCards[0]).toHaveTextContent(sampleIdea2.title); 
-        expect(ideaCards[1]).toHaveTextContent(sampleIdea1.title); 
+      ideaCards = screen.getAllByTestId(/blueprint-card-/);
+      expect(ideaCards[0]).toHaveTextContent(sampleIdea2.title);
+      expect(ideaCards[1]).toHaveTextContent(sampleIdea1.title);
     });
   });
 
   test('displays message when no ideas are present', () => {
     renderIdeaList({ ...sampleProject, ideas: [] });
     expect(screen.getByText(/This constellation holds no blueprints yet./i)).toBeInTheDocument();
-    expect(screen.getByText(/Chart your first blueprint by selecting 'New Idea'./i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Chart your first blueprint by selecting 'New Idea'./i)
+    ).toBeInTheDocument();
   });
 
   test('displays message when no project attachments are present', () => {
     renderIdeaList({ ...sampleProject, attachments: [] });
-    expect(screen.getByText(/No support artifacts anchored to this constellation yet./i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/No support artifacts anchored to this constellation yet./i)
+    ).toBeInTheDocument();
   });
 });

--- a/components/IdeaList.tsx
+++ b/components/IdeaList.tsx
@@ -6,12 +6,20 @@ import Button from './Button';
 import Modal from './Modal';
 import * as fileService from '../services/fileService';
 import { exportViewAsPdfZine } from '../utils/zineExporter'; // Import Zine Exporter
-import BlueprintCard from './BlueprintCard'; 
-import { 
-    PlusCircleIcon, ArrowLeftIcon, DocumentDuplicateIcon, DocumentTextIcon,
-    TrashIcon, PhotoIcon, ArrowUpTrayIcon, DocumentIcon, ArrowDownTrayIcon, PaperClipIcon,
-    DocumentChartBarIcon // New icon
-} from './icons'; 
+import BlueprintCard from './BlueprintCard';
+import {
+  PlusCircleIcon,
+  ArrowLeftIcon,
+  DocumentDuplicateIcon,
+  DocumentTextIcon,
+  TrashIcon,
+  PhotoIcon,
+  ArrowUpTrayIcon,
+  DocumentIcon,
+  ArrowDownTrayIcon,
+  PaperClipIcon,
+  DocumentChartBarIcon, // New icon
+} from './icons';
 import { staggerContainer, staggerItem } from '../motion/variants';
 import { useSortedIdeas } from '../utils/zineExporter';
 
@@ -29,19 +37,26 @@ const MAX_LOGO_SIZE_MB = 2;
 const ALLOWED_LOGO_TYPES = ['image/png', 'image/jpeg', 'image/svg+xml'];
 const BLUEPRINT_CARD_ITEM_CLASS = 'blueprint-card-list-item'; // Class for PDF capture
 
-const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIdea, onBackToProjects, addNotification, onUpdateProject }) => {
+const IdeaList: React.FC<IdeaListProps> = ({
+  project,
+  onEditIdea,
+  onCreateNewIdea,
+  onBackToProjects,
+  addNotification,
+  onUpdateProject,
+}) => {
   const [ideaToDelete, setIdeaToDelete] = useState<Idea | null>(null);
   const [sortOption, setSortOption] = useState<SortOption>('updatedAt_desc');
   const [isExportingProjectZine, setIsExportingProjectZine] = useState(false); // New state
   const logoInputRef = useRef<HTMLInputElement>(null);
   const projectAttachmentInputRef = useRef<HTMLInputElement>(null);
-  
+
   const handleDeleteIdea = () => {
     if (!ideaToDelete) return;
     try {
       const updatedProject = {
         ...project,
-        ideas: project.ideas.filter(idea => idea.id !== ideaToDelete.id),
+        ideas: project.ideas.filter((idea) => idea.id !== ideaToDelete.id),
       };
       onUpdateProject(updatedProject);
       addNotification(`Blueprint "${ideaToDelete.title}" disassembled.`, 'success');
@@ -57,7 +72,10 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
       await fileService.exportProjectAsZip(project);
       addNotification(`Constellation "${project.name}" export (ZIP) initiated.`, 'success'); // Clarified ZIP
     } catch (error) {
-      addNotification(`Failed to export constellation: ${error instanceof Error ? error.message : String(error)}`, 'error'); // Updated
+      addNotification(
+        `Failed to export constellation: ${error instanceof Error ? error.message : String(error)}`,
+        'error'
+      ); // Updated
       console.error(error);
     }
   };
@@ -68,7 +86,10 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
       return;
     }
     setIsExportingProjectZine(true);
-    addNotification(`Preparing Constellation Zine for "${project.name}"... This may take a moment.`, 'info');
+    addNotification(
+      `Preparing Constellation Zine for "${project.name}"... This may take a moment.`,
+      'info'
+    );
     try {
       await exportViewAsPdfZine({
         pageSelector: `.${BLUEPRINT_CARD_ITEM_CLASS}`, // Target each BlueprintCard's li
@@ -76,23 +97,31 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
       });
       addNotification(`Constellation Zine for "${project.name}" exported successfully.`, 'success');
     } catch (error) {
-      addNotification(`Failed to export Constellation Zine: ${error instanceof Error ? error.message : String(error)}`, 'error');
+      addNotification(
+        `Failed to export Constellation Zine: ${error instanceof Error ? error.message : String(error)}`,
+        'error'
+      );
       console.error(error);
     }
     setIsExportingProjectZine(false);
   };
-
 
   const handleLogoUpload = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
     if (!ALLOWED_LOGO_TYPES.includes(file.type)) {
-      addNotification(`This sigil's material isn't quite right. Try PNG, JPG, or SVG. (Found: ${file.type})`, 'error'); // Updated
+      addNotification(
+        `This sigil's material isn't quite right. Try PNG, JPG, or SVG. (Found: ${file.type})`,
+        'error'
+      ); // Updated
       return;
     }
     if (file.size > MAX_LOGO_SIZE_MB * 1024 * 1024) {
-      addNotification(`This sigil is too massive for the forge! Max size: ${MAX_LOGO_SIZE_MB}MB.`, 'error'); // Updated
+      addNotification(
+        `This sigil is too massive for the forge! Max size: ${MAX_LOGO_SIZE_MB}MB.`,
+        'error'
+      ); // Updated
       return;
     }
 
@@ -103,13 +132,14 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
       addNotification('Constellation sigil updated successfully.', 'success'); // Updated
     } catch (error) {
       addNotification('Sigil upload failed. Try a different cosmic image.', 'error'); // Updated
-      console.error("Logo upload error:", error);
+      console.error('Logo upload error:', error);
     }
-    if (logoInputRef.current) logoInputRef.current.value = ""; 
+    if (logoInputRef.current) logoInputRef.current.value = '';
   };
 
   const handleRemoveLogo = () => {
-    if (window.confirm("Are you sure you want to clear this constellation's sigil?")) { // Slightly rephrased confirm
+    if (window.confirm("Are you sure you want to clear this constellation's sigil?")) {
+      // Slightly rephrased confirm
       const updatedProject = { ...project, logo: undefined };
       onUpdateProject(updatedProject);
       addNotification('Constellation sigil has been cleared.', 'info'); // Updated
@@ -117,58 +147,74 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
   };
 
   const processProjectFile = async (file: File): Promise<Attachment | null> => {
-    const common = { id: crypto.randomUUID(), name: fileService.sanitizeFilename(file.name), mimeType: file.type, size: file.size };
-    if (file.type.startsWith('image/')) return { ...common, type: 'image', content: await fileService.readFileAsBase64(file) };
-    if (file.type === 'text/plain' || file.type === 'text/markdown') return { ...common, type: 'text', content: await fileService.readFileAsText(file) };
+    const common = {
+      id: crypto.randomUUID(),
+      name: fileService.sanitizeFilename(file.name),
+      mimeType: file.type,
+      size: file.size,
+    };
+    if (file.type.startsWith('image/'))
+      return { ...common, type: 'image', content: await fileService.readFileAsBase64(file) };
+    if (file.type === 'text/plain' || file.type === 'text/markdown')
+      return { ...common, type: 'text', content: await fileService.readFileAsText(file) };
     return { ...common, type: 'other', content: await fileService.readFileAsBase64(file) };
   };
 
-  const handleProjectFileUpload = useCallback(async (files: FileList | File[] | null) => {
-    if (!files || files.length === 0) return;
-    addNotification('Materializing your artifacts...', 'info'); // Updated
-    const newProjectAttachmentsBatch: Attachment[] = [];
+  const handleProjectFileUpload = useCallback(
+    async (files: FileList | File[] | null) => {
+      if (!files || files.length === 0) return;
+      addNotification('Materializing your artifacts...', 'info'); // Updated
+      const newProjectAttachmentsBatch: Attachment[] = [];
 
-    for (const file of Array.from(files)) {
+      for (const file of Array.from(files)) {
         // No ZIP processing for project-level attachments for simplicity, direct file attachment
         const attachment = await processProjectFile(file);
         if (attachment) {
-            newProjectAttachmentsBatch.push(attachment);
+          newProjectAttachmentsBatch.push(attachment);
         }
-    }
-    
-    if (newProjectAttachmentsBatch.length > 0) {
+      }
+
+      if (newProjectAttachmentsBatch.length > 0) {
         // Update attachment handlers to use onUpdateProject
         const updatedProject = {
           ...project,
           attachments: [...(project.attachments || []), ...newProjectAttachmentsBatch],
         };
         onUpdateProject(updatedProject);
-        addNotification(`${newProjectAttachmentsBatch.length} support artifact(s) anchored to constellation.`, 'success'); // Updated
-    }
-    if (projectAttachmentInputRef.current) projectAttachmentInputRef.current.value = "";
-  }, [project.id, onUpdateProject, addNotification]);
+        addNotification(
+          `${newProjectAttachmentsBatch.length} support artifact(s) anchored to constellation.`,
+          'success'
+        ); // Updated
+      }
+      if (projectAttachmentInputRef.current) projectAttachmentInputRef.current.value = '';
+    },
+    [project.id, onUpdateProject, addNotification]
+  );
 
   const handleDownloadProjectAttachment = (attachment: Attachment) => {
     try {
-        const blob = fileService.base64ToBlob(attachment.content, attachment.mimeType);
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = attachment.name;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(link.href);
-        addNotification(`Beaming down artifact "${attachment.name}"...`, 'info'); // Updated
+      const blob = fileService.base64ToBlob(attachment.content, attachment.mimeType);
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = attachment.name;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(link.href);
+      addNotification(`Beaming down artifact "${attachment.name}"...`, 'info'); // Updated
     } catch (error) {
-        addNotification(`Artifact "${attachment.name}" lost in transit: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error'); // Updated
+      addNotification(
+        `Artifact "${attachment.name}" lost in transit: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'error'
+      ); // Updated
     }
   };
 
   const handleDeleteProjectAttachment = (attachmentId: string) => {
-    if (window.confirm("Are you sure you want to unlink this artifact from the constellation?")) {
+    if (window.confirm('Are you sure you want to unlink this artifact from the constellation?')) {
       const updatedProject = {
         ...project,
-        attachments: (project.attachments || []).filter(att => att.id !== attachmentId),
+        attachments: (project.attachments || []).filter((att) => att.id !== attachmentId),
       };
       onUpdateProject(updatedProject);
       addNotification('Constellation artifact unlinked.', 'info');
@@ -176,70 +222,86 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
   };
 
   const getFileIcon = (type: Attachment['type']) => {
-    if (type === 'image') return <PhotoIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
-    if (type === 'text') return <DocumentTextIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
+    if (type === 'image')
+      return <PhotoIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
+    if (type === 'text')
+      return <DocumentTextIcon className="w-5 h-5 text-theme-accent-primary mr-2 flex-shrink-0" />;
     return <DocumentIcon className="w-5 h-5 text-theme-text-secondary mr-2 flex-shrink-0" />;
   };
 
   const sortedIdeas = useSortedIdeas(project.ideas, sortOption);
-  
+
   const isActionInProgress = isExportingProjectZine; // Combine other loading states here if any
 
   return (
-    <motion.div 
+    <motion.div
       className="p-4 sm:p-6 md:p-8 w-full max-w-5xl mx-auto"
-      initial={{ opacity: 0, x: 50 }} 
+      initial={{ opacity: 0, x: 50 }}
       animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -50 }} 
+      exit={{ opacity: 0, x: -50 }}
       transition={{ type: 'spring', stiffness: 70, damping: 20 }}
     >
       {/* Project Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 sm:mb-8 pb-4 border-b border-theme-border-primary">
         <div className="w-full sm:w-auto mb-4 sm:mb-0">
-          <Button onClick={onBackToProjects} variant="ghost" size="sm" className="mb-2" leftIcon={<ArrowLeftIcon className="w-5 h-5"/>} disabled={isActionInProgress}>
+          <Button
+            onClick={onBackToProjects}
+            variant="ghost"
+            size="sm"
+            className="mb-2"
+            leftIcon={<ArrowLeftIcon className="w-5 h-5" />}
+            disabled={isActionInProgress}
+          >
             Back to Navigator
           </Button>
           <div className="flex items-center space-x-3 mt-1">
             {project.logo ? (
-              <img src={project.logo} alt={`${project.name} logo`} className="w-12 h-12 sm:w-16 sm:h-16 object-cover rounded-lg border-2 border-theme-accent-primary/50 shadow-md" />
+              <img
+                src={project.logo}
+                alt={`${project.name} logo`}
+                className="w-12 h-12 sm:w-16 sm:h-16 object-cover rounded-lg border-2 border-theme-accent-primary/50 shadow-md"
+              />
             ) : (
               <div className="w-12 h-12 sm:w-16 sm:h-16 bg-theme-bg-accent rounded-lg flex items-center justify-center border-2 border-theme-border-primary/50">
                 <PhotoIcon className="w-6 h-6 sm:w-8 sm:h-8 text-theme-accent-primary/70" />
               </div>
             )}
             <div>
-              <h2 className="text-2xl sm:text-3xl font-sans font-bold text-theme-accent-primary truncate" title={project.name}>
+              <h2
+                className="text-2xl sm:text-3xl font-sans font-bold text-theme-accent-primary truncate"
+                title={project.name}
+              >
                 Constellation: {project.name}
               </h2>
               <div className="flex items-center space-x-2 mt-1.5">
-                <input 
-                  type="file" 
-                  accept=".png,.jpg,.jpeg,.svg" 
-                  ref={logoInputRef} 
-                  onChange={handleLogoUpload} 
+                <input
+                  type="file"
+                  accept=".png,.jpg,.jpeg,.svg"
+                  ref={logoInputRef}
+                  onChange={handleLogoUpload}
                   className="hidden"
                   id="project-logo-upload-input"
                   aria-label="Upload project logo"
                   disabled={isActionInProgress}
                 />
-                <Button 
-                  variant="outline" 
-                  size="sm" 
+                <Button
+                  variant="outline"
+                  size="sm"
                   className="!text-xs !px-2 !py-1"
                   onClick={() => logoInputRef.current?.click()}
-                  leftIcon={<ArrowUpTrayIcon className="w-3.5 h-3.5"/>}
-                  title={project.logo ? "Change Constellation Sigil" : "Set Constellation Sigil"}
+                  leftIcon={<ArrowUpTrayIcon className="w-3.5 h-3.5" />}
+                  title={project.logo ? 'Change Constellation Sigil' : 'Set Constellation Sigil'}
                   disabled={isActionInProgress}
                 >
                   {project.logo ? 'Change Sigil' : 'Set Sigil'}
                 </Button>
                 {project.logo && (
-                  <Button 
-                    variant="ghost" 
-                    size="sm" 
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     className="!text-xs !px-2 !py-1 text-status-error/80 hover:text-status-error"
                     onClick={handleRemoveLogo}
-                    leftIcon={<TrashIcon className="w-3.5 h-3.5"/>}
+                    leftIcon={<TrashIcon className="w-3.5 h-3.5" />}
                     title="Clear Constellation Sigil"
                     disabled={isActionInProgress}
                   >
@@ -251,66 +313,104 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
           </div>
         </div>
         <div className="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-3 self-start sm:self-center mt-4 sm:mt-0">
-          <Button onClick={handleExportProjectZine} variant="outline" size="md" leftIcon={<DocumentChartBarIcon className="w-5 h-5"/>} isLoading={isExportingProjectZine} disabled={isActionInProgress && !isExportingProjectZine} aria-label="Export constellation as PDF Zine">
+          <Button
+            onClick={handleExportProjectZine}
+            variant="outline"
+            size="md"
+            leftIcon={<DocumentChartBarIcon className="w-5 h-5" />}
+            isLoading={isExportingProjectZine}
+            disabled={isActionInProgress && !isExportingProjectZine}
+            aria-label="Export constellation as PDF Zine"
+          >
             Export Zine (PDF)
           </Button>
-          <Button onClick={handleExportProject} variant="outline" size="md" leftIcon={<DocumentDuplicateIcon className="w-5 h-5"/>} disabled={isActionInProgress} aria-label="Export constellation as ZIP">
+          <Button
+            onClick={handleExportProject}
+            variant="outline"
+            size="md"
+            leftIcon={<DocumentDuplicateIcon className="w-5 h-5" />}
+            disabled={isActionInProgress}
+            aria-label="Export constellation as ZIP"
+          >
             Export (ZIP)
           </Button>
-          <Button onClick={onCreateNewIdea} variant="default" size="md" leftIcon={<PlusCircleIcon className="w-5 h-5"/>} disabled={isActionInProgress} aria-label="Create new blueprint">
+          <Button
+            onClick={onCreateNewIdea}
+            variant="default"
+            size="md"
+            leftIcon={<PlusCircleIcon className="w-5 h-5" />}
+            disabled={isActionInProgress}
+            aria-label="Create new blueprint"
+          >
             New Blueprint
           </Button>
         </div>
       </div>
-      
+
       {/* Ideas Section */}
       <div className="mb-8">
         <h3 className="text-xl font-sans font-semibold text-theme-text-primary mb-1">Blueprints</h3>
-        <p className="text-sm text-theme-text-secondary mb-3">These are the star-charts of your ideas. Malleable. Luminous. Forged.</p>
+        <p className="text-sm text-theme-text-secondary mb-3">
+          These are the star-charts of your ideas. Malleable. Luminous. Forged.
+        </p>
         {sortedIdeas.length > 0 && (
           <div className="mb-4 flex items-center justify-end">
-              <label htmlFor="sort-ideas" className="text-sm text-theme-text-secondary mr-2 font-sans">Arrange Blueprints by:</label>
-              <select 
-                  id="sort-ideas"
-                  value={sortOption}
-                  onChange={(e) => setSortOption(e.target.value as SortOption)}
-                  className="bg-theme-bg-accent border border-theme-border-primary/50 text-theme-text-primary text-sm rounded-md focus:ring-1 focus:ring-theme-accent-primary focus:border-theme-accent-primary p-2 font-sans"
-                  disabled={isActionInProgress}
-              >
-                  <option value="updatedAt_desc">Most Recently Forged</option>
-                  <option value="title_asc">Name (A-Z, Ascending)</option>
-                  <option value="createdAt_desc">Ignition Date (Newest First)</option>
-                  <option value="createdAt_asc">Ignition Date (Oldest First)</option>
-              </select>
+            <label
+              htmlFor="sort-ideas"
+              className="text-sm text-theme-text-secondary mr-2 font-sans"
+            >
+              Arrange Blueprints by:
+            </label>
+            <select
+              id="sort-ideas"
+              value={sortOption}
+              onChange={(e) => setSortOption(e.target.value as SortOption)}
+              className="bg-theme-bg-accent border border-theme-border-primary/50 text-theme-text-primary text-sm rounded-md focus:ring-1 focus:ring-theme-accent-primary focus:border-theme-accent-primary p-2 font-sans"
+              disabled={isActionInProgress}
+            >
+              <option value="updatedAt_desc">Most Recently Forged</option>
+              <option value="title_asc">Name (A-Z, Ascending)</option>
+              <option value="createdAt_desc">Ignition Date (Newest First)</option>
+              <option value="createdAt_asc">Ignition Date (Oldest First)</option>
+            </select>
           </div>
         )}
         <AnimatePresence>
           {sortedIdeas.length > 0 ? (
-            <motion.ul 
+            <motion.ul
               className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6"
               variants={staggerContainer}
               initial="hidden"
               animate="visible"
             >
-              {sortedIdeas.map(idea => (
-                <motion.li key={idea.id} variants={staggerItem} className={BLUEPRINT_CARD_ITEM_CLASS}>
-                  <BlueprintCard 
-                    item={idea} 
+              {sortedIdeas.map((idea) => (
+                <motion.li
+                  key={idea.id}
+                  variants={staggerItem}
+                  className={BLUEPRINT_CARD_ITEM_CLASS}
+                >
+                  <BlueprintCard
+                    item={idea}
                     type="idea"
-                    onSelect={() => !isActionInProgress && onEditIdea(idea)} 
+                    onSelect={() => !isActionInProgress && onEditIdea(idea)}
                     onDelete={() => !isActionInProgress && setIdeaToDelete(idea)}
                   />
                 </motion.li>
               ))}
             </motion.ul>
           ) : (
-            <motion.div 
+            <motion.div
               className="text-center py-12 sm:py-16 font-sans bg-theme-bg-accent/30 rounded-lg border border-theme-border-primary"
-              initial={{ opacity: 0 }} animate={{ opacity: 1, transition: {delay: 0.2} }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, transition: { delay: 0.2 } }}
             >
-              <DocumentTextIcon className="w-16 h-16 sm:w-20 sm:h-20 mx-auto text-theme-accent-primary/50 mb-4 opacity-70"/>
-              <p className="text-lg sm:text-xl text-theme-text-primary">This constellation holds no blueprints yet.</p>
-              <p className="text-sm text-theme-text-secondary mt-2">Chart your first blueprint by selecting 'New Blueprint'.</p>
+              <DocumentTextIcon className="w-16 h-16 sm:w-20 sm:h-20 mx-auto text-theme-accent-primary/50 mb-4 opacity-70" />
+              <p className="text-lg sm:text-xl text-theme-text-primary">
+                This constellation holds no blueprints yet.
+              </p>
+              <p className="text-sm text-theme-text-secondary mt-2">
+                Chart your first blueprint by selecting 'New Blueprint'.
+              </p>
             </motion.div>
           )}
         </AnimatePresence>
@@ -319,58 +419,82 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
       {/* Project Support Files Section */}
       <div className="mt-10 pt-6 border-t border-theme-border-primary">
         <div className="flex justify-between items-center mb-4">
-            <h3 className="text-xl font-sans font-semibold text-theme-text-primary flex items-center">
-                <PaperClipIcon className="w-6 h-6 mr-2 text-theme-accent-primary"/> Constellation Support Artifacts 
-                <span className="ml-2 text-sm text-theme-accent-primary">({project.attachments?.length || 0})</span>
-            </h3>
-            <input 
-                type="file" 
-                multiple 
-                ref={projectAttachmentInputRef} 
-                onChange={(e) => handleProjectFileUpload(e.target.files)} 
-                className="hidden" 
-                id="project-file-upload-input"
-                aria-label="Upload files to project"
-                disabled={isActionInProgress}
-            />
-            <Button 
-                type="button" 
-                variant="outline" 
-                size="md" 
-                onClick={() => projectAttachmentInputRef.current?.click()}
-                leftIcon={<PlusCircleIcon className="w-5 h-5"/>}
-                disabled={isActionInProgress}
-            >
-                Add Artifact(s)
-            </Button>
+          <h3 className="text-xl font-sans font-semibold text-theme-text-primary flex items-center">
+            <PaperClipIcon className="w-6 h-6 mr-2 text-theme-accent-primary" /> Constellation
+            Support Artifacts
+            <span className="ml-2 text-sm text-theme-accent-primary">
+              ({project.attachments?.length || 0})
+            </span>
+          </h3>
+          <input
+            type="file"
+            multiple
+            ref={projectAttachmentInputRef}
+            onChange={(e) => handleProjectFileUpload(e.target.files)}
+            className="hidden"
+            id="project-file-upload-input"
+            aria-label="Upload files to project"
+            disabled={isActionInProgress}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            onClick={() => projectAttachmentInputRef.current?.click()}
+            leftIcon={<PlusCircleIcon className="w-5 h-5" />}
+            disabled={isActionInProgress}
+          >
+            Add Artifact(s)
+          </Button>
         </div>
         {project.attachments && project.attachments.length > 0 ? (
-            <ul className="space-y-3">
-            {project.attachments.map(att => (
-                <li key={att.id} className="flex items-center justify-between p-3 bg-theme-bg-accent rounded-lg shadow hover:shadow-md transition-shadow">
+          <ul className="space-y-3">
+            {project.attachments.map((att) => (
+              <li
+                key={att.id}
+                className="flex items-center justify-between p-3 bg-theme-bg-accent rounded-lg shadow hover:shadow-md transition-shadow"
+              >
                 <div className="flex items-center truncate mr-2">
-                    {getFileIcon(att.type)}
-                    <span className="text-sm text-theme-text-primary truncate" title={att.name}>{att.name}</span>
-                    <span className="text-xs text-theme-text-secondary ml-2 flex-shrink-0">({Math.round(att.size / 1024)} KB)</span>
+                  {getFileIcon(att.type)}
+                  <span className="text-sm text-theme-text-primary truncate" title={att.name}>
+                    {att.name}
+                  </span>
+                  <span className="text-xs text-theme-text-secondary ml-2 flex-shrink-0">
+                    ({Math.round(att.size / 1024)} KB)
+                  </span>
                 </div>
                 <div className="flex space-x-2 flex-shrink-0">
-                    <Button type="button" variant="icon" size="sm" onClick={() => handleDownloadProjectAttachment(att)} title="Download file" disabled={isActionInProgress}>
-                    <ArrowDownTrayIcon className="w-4 h-4 text-theme-accent-primary"/>
-                    </Button>
-                    <Button type="button" variant="icon" size="sm" onClick={() => handleDeleteProjectAttachment(att.id)} title="Delete file" className="text-status-error hover:bg-status-error/10" disabled={isActionInProgress}>
-                    <TrashIcon className="w-4 h-4"/>
-                    </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => handleDownloadProjectAttachment(att)}
+                    title="Download file"
+                    disabled={isActionInProgress}
+                  >
+                    <ArrowDownTrayIcon className="w-4 h-4 text-theme-accent-primary" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => handleDeleteProjectAttachment(att.id)}
+                    title="Delete file"
+                    className="text-status-error hover:bg-status-error/10"
+                    disabled={isActionInProgress}
+                  >
+                    <TrashIcon className="w-4 h-4" />
+                  </Button>
                 </div>
-                </li>
+              </li>
             ))}
-            </ul>
+          </ul>
         ) : (
-            <p className="text-sm text-theme-text-secondary text-center py-6 bg-theme-bg-accent/30 rounded-lg border border-theme-border-primary">
-                No support artifacts anchored to this constellation yet.
-            </p>
+          <p className="text-sm text-theme-text-secondary text-center py-6 bg-theme-bg-accent/30 rounded-lg border border-theme-border-primary">
+            No support artifacts anchored to this constellation yet.
+          </p>
         )}
       </div>
-
 
       {/* Delete Idea Modal */}
       <Modal
@@ -378,10 +502,16 @@ const IdeaList: React.FC<IdeaListProps> = ({ project, onEditIdea, onCreateNewIde
         onClose={() => setIdeaToDelete(null)}
         title={`Disassemble Blueprint "${ideaToDelete?.title}"?`}
       >
-        <p className="text-theme-text-primary">This blueprint will be returned to stardust. This action is irreversible.</p>
+        <p className="text-theme-text-primary">
+          This blueprint will be returned to stardust. This action is irreversible.
+        </p>
         <div className="mt-6 flex justify-end space-x-3">
-          <Button variant="ghost" onClick={() => setIdeaToDelete(null)}>Cancel</Button>
-          <Button variant="danger" onClick={handleDeleteIdea}>Disassemble</Button>
+          <Button variant="ghost" onClick={() => setIdeaToDelete(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleDeleteIdea}>
+            Disassemble
+          </Button>
         </div>
       </Modal>
     </motion.div>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { motion, Variants, TargetAndTransition } from 'framer-motion';
 
@@ -30,7 +29,6 @@ const logoVariants: Variants = {
   },
 };
 
-
 const itemVariants: Variants = {
   hidden: { y: 20, opacity: 0 },
   visible: {
@@ -49,72 +47,69 @@ const buttonHover: TargetAndTransition = {
 };
 
 const LandingPage: React.FC<LandingPageProps> = ({ onEnterForge, onTryDemo }) => (
-    <motion.div
-      className="flex flex-col items-center justify-center min-h-screen text-center p-4 relative"
-      variants={containerVariants}
-      initial="hidden"
-      animate="visible"
-    >
-      <motion.div 
-        variants={logoVariants}
-        className="pt-10 mb-6 z-10"
-      >
-        <motion.img 
-          src="https://cdn.jsdelivr.net/gh/agattone96/ideaforge/logo.png"
-          alt="Cosmic Forge Logo"
-          className="mx-auto w-full h-auto max-w-[300px] sm:max-w-[400px] drop-shadow-glow-pink"
-          animate={{
-            scale: [1, 1.05, 1],
-          }}
-          transition={{
-            duration: 4,
-            repeat: Infinity,
-            ease: "easeInOut",
-          }}
-        />
-      </motion.div>
-
-      <motion.h1
-        variants={itemVariants}
-        className="font-sans font-bold text-4xl sm:text-5xl md:text-6xl text-cosmic-text-primary uppercase tracking-wider mb-4"
-      >
-        Welcome to IdeaForge
-      </motion.h1>
-
-      <motion.p
-        variants={itemVariants}
-        className="font-body text-lg sm:text-xl text-cosmic-text-secondary mb-10"
-      >
-        Think freely. Build clearly.
-      </motion.p>
-
-      <motion.div
-        variants={itemVariants}
-        className="flex flex-col sm:flex-row items-center gap-4 z-10"
-      >
-        <motion.button
-          onClick={onEnterForge}
-          className="w-full sm:w-auto px-10 py-4 font-body font-bold text-cosmic-text-primary bg-gradient-to-r from-cosmic-pink to-cosmic-orange rounded-xl shadow-lg shadow-cosmic-pink/20 hover:shadow-glow-lg transition-shadow duration-300"
-          whileHover={buttonHover}
-        >
-          Enter the Forge
-        </motion.button>
-        <motion.button
-          onClick={onTryDemo}
-          className="w-full sm:w-auto px-10 py-4 font-body font-bold text-cosmic-text-primary border-2 border-cosmic-pink rounded-xl bg-transparent hover:bg-gradient-to-r hover:from-cosmic-pink hover:to-cosmic-orange hover:border-transparent transition-all duration-300"
-          whileHover={buttonHover}
-        >
-          Try Demo
-        </motion.button>
-      </motion.div>
-
-      <motion.p
-        variants={itemVariants}
-        className="font-body text-sm text-cosmic-text-secondary uppercase tracking-[0.1em] absolute bottom-8"
-      >
-        // Your Cosmic Forge Awaits //
-      </motion.p>
+  <motion.div
+    className="flex flex-col items-center justify-center min-h-screen text-center p-4 relative"
+    variants={containerVariants}
+    initial="hidden"
+    animate="visible"
+  >
+    <motion.div variants={logoVariants} className="pt-10 mb-6 z-10">
+      <motion.img
+        src="https://cdn.jsdelivr.net/gh/agattone96/ideaforge/logo.png"
+        alt="Cosmic Forge Logo"
+        className="mx-auto w-full h-auto max-w-[300px] sm:max-w-[400px] drop-shadow-glow-pink"
+        animate={{
+          scale: [1, 1.05, 1],
+        }}
+        transition={{
+          duration: 4,
+          repeat: Infinity,
+          ease: 'easeInOut',
+        }}
+      />
     </motion.div>
-  );
+
+    <motion.h1
+      variants={itemVariants}
+      className="font-sans font-bold text-4xl sm:text-5xl md:text-6xl text-cosmic-text-primary uppercase tracking-wider mb-4"
+    >
+      Welcome to IdeaForge
+    </motion.h1>
+
+    <motion.p
+      variants={itemVariants}
+      className="font-body text-lg sm:text-xl text-cosmic-text-secondary mb-10"
+    >
+      Think freely. Build clearly.
+    </motion.p>
+
+    <motion.div
+      variants={itemVariants}
+      className="flex flex-col sm:flex-row items-center gap-4 z-10"
+    >
+      <motion.button
+        onClick={onEnterForge}
+        className="w-full sm:w-auto px-10 py-4 font-body font-bold text-cosmic-text-primary bg-gradient-to-r from-cosmic-pink to-cosmic-orange rounded-xl shadow-lg shadow-cosmic-pink/20 hover:shadow-glow-lg transition-shadow duration-300"
+        whileHover={buttonHover}
+      >
+        Enter the Forge
+      </motion.button>
+      <motion.button
+        onClick={onTryDemo}
+        className="w-full sm:w-auto px-10 py-4 font-body font-bold text-cosmic-text-primary border-2 border-cosmic-pink rounded-xl bg-transparent hover:bg-gradient-to-r hover:from-cosmic-pink hover:to-cosmic-orange hover:border-transparent transition-all duration-300"
+        whileHover={buttonHover}
+      >
+        Try Demo
+      </motion.button>
+    </motion.div>
+
+    <motion.p
+      variants={itemVariants}
+      className="font-body text-sm text-cosmic-text-secondary uppercase tracking-[0.1em] absolute bottom-8"
+    >
+      // Your Cosmic Forge Awaits //
+    </motion.p>
+  </motion.div>
+);
 
 export default LandingPage;

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence, Variants, Transition } from 'framer-motion';
-import { XMarkIcon } from './icons'; 
+import { XMarkIcon } from './icons';
 import Button from './Button'; // Use the refactored Button
 
 interface ModalProps {
@@ -32,15 +32,15 @@ const modalVariantsDefault: Variants = {
   exit: { opacity: 0, scale: 0.9, y: -20, transition: exitTransition },
 };
 
-const Modal: React.FC<ModalProps> = ({ 
-  isOpen, 
-  onClose, 
-  title, 
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
   titleId = 'modal-title',
   descriptionId = 'modal-description',
-  children, 
-  footer, 
-  size = 'md', 
+  children,
+  footer,
+  size = 'md',
   isGlassmorphic = false,
   className = '',
   prefersReducedMotion = false,
@@ -48,13 +48,18 @@ const Modal: React.FC<ModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocusedElementRef = useRef<HTMLElement | null>(null);
 
-  const modalMotionVariants = prefersReducedMotion ? modalVariantsReducedMotion : modalVariantsDefault;
+  const modalMotionVariants = prefersReducedMotion
+    ? modalVariantsReducedMotion
+    : modalVariantsDefault;
 
-  const handleKeyDown = useCallback((event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      onClose();
-    }
-  }, [onClose]);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose]
+  );
 
   useEffect(() => {
     if (isOpen) {
@@ -76,9 +81,9 @@ const Modal: React.FC<ModalProps> = ({
                 e.preventDefault();
               }
             } else if (document.activeElement === lastElement) {
-                firstElement.focus();
-                e.preventDefault();
-              }
+              firstElement.focus();
+              e.preventDefault();
+            }
           }
         };
         document.addEventListener('keydown', trapFocus);
@@ -91,12 +96,14 @@ const Modal: React.FC<ModalProps> = ({
     }
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      if (previousFocusedElementRef.current && document.body.contains(previousFocusedElementRef.current)) {
+      if (
+        previousFocusedElementRef.current &&
+        document.body.contains(previousFocusedElementRef.current)
+      ) {
         previousFocusedElementRef.current.focus();
       }
     };
   }, [isOpen, handleKeyDown]);
-
 
   const sizeClasses = {
     sm: 'max-w-sm',
@@ -140,7 +147,10 @@ const Modal: React.FC<ModalProps> = ({
             tabIndex={-1} // Make the panel focusable
           >
             <header className="flex justify-between items-center p-4 sm:p-5 border-b border-theme-border-primary flex-shrink-0">
-              <h3 id={titleId} className="text-xl font-display font-semibold text-theme-accent-primary">
+              <h3
+                id={titleId}
+                className="text-xl font-display font-semibold text-theme-accent-primary"
+              >
                 {title}
               </h3>
               <Button
@@ -152,11 +162,14 @@ const Modal: React.FC<ModalProps> = ({
                 <XMarkIcon className="w-6 h-6" />
               </Button>
             </header>
-            
-            <main id={descriptionId} className="p-4 sm:p-5 text-sm sm:text-base leading-relaxed overflow-y-auto flex-grow custom-scrollbar">
+
+            <main
+              id={descriptionId}
+              className="p-4 sm:p-5 text-sm sm:text-base leading-relaxed overflow-y-auto flex-grow custom-scrollbar"
+            >
               {children}
             </main>
-            
+
             {footer && (
               <footer className="flex justify-end space-x-3 p-4 sm:p-5 border-t border-theme-border-primary flex-shrink-0">
                 {footer}

--- a/components/MotionCard.tsx
+++ b/components/MotionCard.tsx
@@ -11,10 +11,10 @@ interface MotionCardProps {
   tiltEnabled?: boolean; // New prop to control tilt
 }
 
-const MotionCard: React.FC<MotionCardProps> = ({ 
-  children, 
-  className, 
-  title, 
+const MotionCard: React.FC<MotionCardProps> = ({
+  children,
+  className,
+  title,
   imageUrl,
   tiltEnabled = true, // Default to true
 }) => {
@@ -38,15 +38,26 @@ const MotionCard: React.FC<MotionCardProps> = ({
 
   const effectiveTiltEnabled = tiltEnabled && !prefersReducedMotion;
 
-  const rotateX = useTransform(mouseYSpring, [-0.5, 0.5], effectiveTiltEnabled ? ['8deg', '-8deg'] : ['0deg', '0deg']);
-  const rotateY = useTransform(mouseXSpring, [-0.5, 0.5], effectiveTiltEnabled ? ['-8deg', '8deg'] : ['0deg', '0deg']);
+  const rotateX = useTransform(
+    mouseYSpring,
+    [-0.5, 0.5],
+    effectiveTiltEnabled ? ['8deg', '-8deg'] : ['0deg', '0deg']
+  );
+  const rotateY = useTransform(
+    mouseXSpring,
+    [-0.5, 0.5],
+    effectiveTiltEnabled ? ['-8deg', '8deg'] : ['0deg', '0deg']
+  );
 
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    if (!effectiveTiltEnabled || !cardRef.current) return;
-    const rect = cardRef.current.getBoundingClientRect();
-    x.set((e.clientX - rect.left) / rect.width - 0.5);
-    y.set((e.clientY - rect.top) / rect.height - 0.5);
-  }, [effectiveTiltEnabled]);
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!effectiveTiltEnabled || !cardRef.current) return;
+      const rect = cardRef.current.getBoundingClientRect();
+      x.set((e.clientX - rect.left) / rect.width - 0.5);
+      y.set((e.clientY - rect.top) / rect.height - 0.5);
+    },
+    [effectiveTiltEnabled]
+  );
 
   const handleMouseLeave = useCallback(() => {
     if (!effectiveTiltEnabled) return;
@@ -56,17 +67,19 @@ const MotionCard: React.FC<MotionCardProps> = ({
 
   const cardVariants: Variants = {
     initial: { opacity: 0, y: 20, filter: 'blur(3px)' },
-    animate: { 
-      opacity: 1, 
+    animate: {
+      opacity: 1,
       y: 0,
       filter: 'blur(0px)',
-      transition: { duration: 0.5, delay: Math.random() * 0.2, ease: [0.25, 1, 0.5, 1] }
+      transition: { duration: 0.5, delay: Math.random() * 0.2, ease: [0.25, 1, 0.5, 1] },
     },
-    hover: effectiveTiltEnabled ? { 
-        scale: 1.03, 
-        boxShadow: 'var(--shadow-card-hover)', // Use theme token
-        transition: { type: 'spring', stiffness: 250, damping: 15 }
-    } : { scale: 1.01, boxShadow: 'var(--shadow-card-hover)' }, // Subtle hover if no tilt
+    hover: effectiveTiltEnabled
+      ? {
+          scale: 1.03,
+          boxShadow: 'var(--shadow-card-hover)', // Use theme token
+          transition: { type: 'spring', stiffness: 250, damping: 15 },
+        }
+      : { scale: 1.01, boxShadow: 'var(--shadow-card-hover)' }, // Subtle hover if no tilt
   };
 
   return (
@@ -78,7 +91,7 @@ const MotionCard: React.FC<MotionCardProps> = ({
         rotateX,
         rotateY,
         transformStyle: 'preserve-3d',
-        perspective: '1200px', 
+        perspective: '1200px',
       }}
       className={`
         relative bg-theme-bg-accent p-space-sm rounded-card shadow-card 
@@ -90,19 +103,25 @@ const MotionCard: React.FC<MotionCardProps> = ({
       animate="animate"
       whileHover="hover"
     >
-      <div 
-        style={{ transform: effectiveTiltEnabled ? 'translateZ(25px)' : 'none' }} 
+      <div
+        style={{ transform: effectiveTiltEnabled ? 'translateZ(25px)' : 'none' }}
         className="transform-gpu" // Hint for GPU acceleration
       >
         {imageUrl && (
-          <img 
-            src={imageUrl} 
-            alt={title || 'Motion Card Image'} 
-            className="w-full h-40 object-cover rounded-md mb-space-xs border border-theme-border-primary/20" 
+          <img
+            src={imageUrl}
+            alt={title || 'Motion Card Image'}
+            className="w-full h-40 object-cover rounded-md mb-space-xs border border-theme-border-primary/20"
           />
         )}
-        {title && <h3 className="text-theme-accent-primary font-display font-semibold text-lg mb-space-xs">{title}</h3>}
-        {children || <p className="text-theme-text-secondary text-sm">Motion card content placeholder.</p>}
+        {title && (
+          <h3 className="text-theme-accent-primary font-display font-semibold text-lg mb-space-xs">
+            {title}
+          </h3>
+        )}
+        {children || (
+          <p className="text-theme-text-secondary text-sm">Motion card content placeholder.</p>
+        )}
       </div>
     </motion.div>
   );

--- a/components/NotificationArea.tsx
+++ b/components/NotificationArea.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { NotificationType } from '../types';
-import { CheckCircleIcon, ExclamationTriangleIcon, InformationCircleIcon, XMarkIcon } from './icons'; // Assuming these icons are themed
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+  XMarkIcon,
+} from './icons'; // Assuming these icons are themed
 
 interface NotificationAreaProps {
   notifications: NotificationType[];
@@ -14,11 +19,29 @@ const notificationVariants = {
   exit: { opacity: 0, scale: 0.5, transition: { duration: 0.2 } },
 };
 
-const Notification: React.FC<{ notification: NotificationType; onDismiss: (id: string) => void }> = ({ notification, onDismiss }) => {
+const Notification: React.FC<{
+  notification: NotificationType;
+  onDismiss: (id: string) => void;
+}> = ({ notification, onDismiss }) => {
   const typeStyles = {
-    success: { bg: 'bg-success/20', border: 'border-success', text: 'text-success', icon: <CheckCircleIcon className="w-5 h-5 mr-2" /> },
-    error: { bg: 'bg-error/20', border: 'border-error', text: 'text-error', icon: <ExclamationTriangleIcon className="w-5 h-5 mr-2" /> },
-    info: { bg: 'bg-amber/20', border: 'border-amber', text: 'text-amber', icon: <InformationCircleIcon className="w-5 h-5 mr-2" /> },
+    success: {
+      bg: 'bg-success/20',
+      border: 'border-success',
+      text: 'text-success',
+      icon: <CheckCircleIcon className="w-5 h-5 mr-2" />,
+    },
+    error: {
+      bg: 'bg-error/20',
+      border: 'border-error',
+      text: 'text-error',
+      icon: <ExclamationTriangleIcon className="w-5 h-5 mr-2" />,
+    },
+    info: {
+      bg: 'bg-amber/20',
+      border: 'border-amber',
+      text: 'text-amber',
+      icon: <InformationCircleIcon className="w-5 h-5 mr-2" />,
+    },
   };
 
   const currentStyle = typeStyles[notification.type];
@@ -54,9 +77,13 @@ const Notification: React.FC<{ notification: NotificationType; onDismiss: (id: s
 };
 
 const NotificationArea: React.FC<NotificationAreaProps> = ({ notifications, onDismiss }) => (
-  <div className="fixed bottom-6 right-6 z-[100] flex flex-col items-end space-y-2" aria-live="polite" role="status">
+  <div
+    className="fixed bottom-6 right-6 z-[100] flex flex-col items-end space-y-2"
+    aria-live="polite"
+    role="status"
+  >
     <AnimatePresence initial={false}>
-      {notifications.map(notif => (
+      {notifications.map((notif) => (
         <Notification key={notif.id} notification={notif} onDismiss={onDismiss} />
       ))}
     </AnimatePresence>

--- a/components/PhraseRotator.tsx
+++ b/components/PhraseRotator.tsx
@@ -29,7 +29,7 @@ const PhraseRotator: React.FC<PhraseRotatorProps> = ({ phrases, interval = 3000,
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -20 }}
-          transition={{ duration: 0.5, ease: "easeInOut" }}
+          transition={{ duration: 0.5, ease: 'easeInOut' }}
           className="absolute inset-0 flex items-center justify-center text-lg md:text-xl text-amber font-sans font-semibold"
         >
           {phrases[currentIndex]}

--- a/components/RippleButton.tsx
+++ b/components/RippleButton.tsx
@@ -1,90 +1,99 @@
 // components/RippleButton.tsx
-import React, { useState, useCallback, MouseEvent, useEffect } from 'react'
-import Button from './Button' // Uses the refactored Button
+import React, { useState, useCallback, MouseEvent, useEffect } from 'react';
+import Button from './Button'; // Uses the refactored Button
 
-type ButtonProps = React.ComponentProps<typeof Button>
+type ButtonProps = React.ComponentProps<typeof Button>;
 
 type Ripple = {
-  id: string
-  x: number
-  y: number
-  diameter: number
-}
+  id: string;
+  x: number;
+  y: number;
+  diameter: number;
+};
 
 interface RippleButtonProps extends ButtonProps {
-  rippleColor?: string
+  rippleColor?: string;
 }
 
-const RippleButton: React.FC<RippleButtonProps> = React.memo(({
-  children,
-  onClick,
-  className = '',
-  rippleColor, // Default will be handled by CSS or derived from theme if needed
-  prefersReducedMotion: propPrefersReducedMotion, // Allow prop override
-  ...props
-}) => {
-  const [ripples, setRipples] = useState<Ripple[]>([])
-  const [systemPrefersReducedMotion, setSystemPrefersReducedMotion] = useState(false);
+const RippleButton: React.FC<RippleButtonProps> = React.memo(
+  ({
+    children,
+    onClick,
+    className = '',
+    rippleColor, // Default will be handled by CSS or derived from theme if needed
+    prefersReducedMotion: propPrefersReducedMotion, // Allow prop override
+    ...props
+  }) => {
+    const [ripples, setRipples] = useState<Ripple[]>([]);
+    const [systemPrefersReducedMotion, setSystemPrefersReducedMotion] = useState(false);
 
-  // Determine actual motion preference
-  const actualPrefersReducedMotion = propPrefersReducedMotion ?? systemPrefersReducedMotion;
+    // Determine actual motion preference
+    const actualPrefersReducedMotion = propPrefersReducedMotion ?? systemPrefersReducedMotion;
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setSystemPrefersReducedMotion(mediaQuery.matches);
-    const handleChange = () => setSystemPrefersReducedMotion(mediaQuery.matches);
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
+    useEffect(() => {
+      const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+      setSystemPrefersReducedMotion(mediaQuery.matches);
+      const handleChange = () => setSystemPrefersReducedMotion(mediaQuery.matches);
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
 
+    const spawnRipple = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        if (actualPrefersReducedMotion) return; // Don't spawn ripple if reduced motion
 
-  const spawnRipple = useCallback((event: MouseEvent<HTMLButtonElement>) => {
-    if (actualPrefersReducedMotion) return; // Don't spawn ripple if reduced motion
+        const rect = event.currentTarget.getBoundingClientRect();
+        const diameter = Math.max(rect.width, rect.height) * 2;
+        const x = event.clientX - rect.left - diameter / 2;
+        const y = event.clientY - rect.top - diameter / 2;
+        const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+        setRipples((prev) => [...prev, { id, x, y, diameter }]);
+      },
+      [actualPrefersReducedMotion]
+    );
 
-    const rect = event.currentTarget.getBoundingClientRect()
-    const diameter = Math.max(rect.width, rect.height) * 2
-    const x = event.clientX - rect.left - diameter / 2
-    const y = event.clientY - rect.top - diameter / 2
-    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
-    setRipples(prev => [...prev, { id, x, y, diameter }])
-  }, [actualPrefersReducedMotion])
+    const removeRipple = useCallback((id: string) => {
+      setRipples((prev) => prev.filter((r) => r.id !== id));
+    }, []);
 
-  const removeRipple = useCallback((id: string) => {
-    setRipples(prev => prev.filter(r => r.id !== id))
-  }, [])
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        spawnRipple(event);
+        onClick?.(event);
+      },
+      [spawnRipple, onClick]
+    );
 
-  const handleClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
-    spawnRipple(event)
-    onClick?.(event)
-  }, [spawnRipple, onClick])
+    const finalRippleColor =
+      rippleColor || 'var(--color-accent-primary-transparent, rgba(255, 191, 0, 0.4))';
 
-  const finalRippleColor = rippleColor || 'var(--color-accent-primary-transparent, rgba(255, 191, 0, 0.4))';
+    return (
+      <Button
+        {...props}
+        onClick={handleClick}
+        className={`relative overflow-hidden ${className}`}
+        prefersReducedMotion={actualPrefersReducedMotion} // Pass down to base Button
+      >
+        {children}
+        {!actualPrefersReducedMotion &&
+          ripples.map(({ id, x, y, diameter }) => (
+            <span
+              key={id}
+              className="absolute block pointer-events-none rounded-full animate-ripple"
+              style={{
+                left: x,
+                top: y,
+                width: diameter,
+                height: diameter,
+                backgroundColor: finalRippleColor,
+              }}
+              onAnimationEnd={() => removeRipple(id)}
+              aria-hidden="true"
+            />
+          ))}
+      </Button>
+    );
+  }
+);
 
-  return (
-    <Button
-      {...props}
-      onClick={handleClick}
-      className={`relative overflow-hidden ${className}`}
-      prefersReducedMotion={actualPrefersReducedMotion} // Pass down to base Button
-    >
-      {children}
-      {!actualPrefersReducedMotion && ripples.map(({ id, x, y, diameter }) => (
-        <span
-          key={id}
-          className="absolute block pointer-events-none rounded-full animate-ripple"
-          style={{
-            left: x,
-            top: y,
-            width: diameter,
-            height: diameter,
-            backgroundColor: finalRippleColor,
-          }}
-          onAnimationEnd={() => removeRipple(id)}
-          aria-hidden="true"
-        />
-      ))}
-    </Button>
-  )
-})
-
-export default RippleButton
+export default RippleButton;

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -4,9 +4,15 @@ import Modal from './Modal';
 import Button from './Button';
 import { NotificationType } from '../types';
 import * as Storage from '../services/localStorageService';
-import { 
-    ArrowDownTrayIcon, ArrowUpTrayIcon, SparklesIcon, TrashIcon, CogIcon,
-    AdjustmentsHorizontalIcon, SquaresPlusIcon, PaletteIcon
+import {
+  ArrowDownTrayIcon,
+  ArrowUpTrayIcon,
+  SparklesIcon,
+  TrashIcon,
+  CogIcon,
+  AdjustmentsHorizontalIcon,
+  SquaresPlusIcon,
+  PaletteIcon,
 } from './icons';
 import { ThemeName } from '../styles/theme';
 
@@ -27,23 +33,35 @@ const sectionItemVariants: Variants = {
   },
 };
 
-const SettingItem: React.FC<{title: string; description?: string; children: React.ReactNode; className?: string}> = ({ title, description, children, className }) => (
+const SettingItem: React.FC<{
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+}> = ({ title, description, children, className }) => (
   <div className={`py-3 ${className || ''}`}>
     <h5 className="font-semibold font-display text-theme-text-primary mb-1">{title}</h5>
-    {description && <p className="text-xs text-theme-text-secondary mb-2 max-w-prose">{description}</p>}
+    {description && (
+      <p className="text-xs text-theme-text-secondary mb-2 max-w-prose">{description}</p>
+    )}
     <div className="mt-2">{children}</div>
   </div>
 );
 
-const Section: React.FC<{title: string; children: React.ReactNode; className?: string; icon?: React.ReactNode}> = ({title, children, className, icon}) => (
-    <motion.div variants={sectionItemVariants} className={`py-4 ${className || ''}`}>
-      <div className="flex items-center mb-3">
-        {icon && <span className="mr-2 text-theme-accent-primary">{icon}</span>}
-        <h4 className="font-display font-semibold text-theme-accent-primary text-lg">{title}</h4>
-      </div>
-      <div className="font-body space-y-3">{children}</div>
-    </motion.div>
-  );
+const Section: React.FC<{
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+  icon?: React.ReactNode;
+}> = ({ title, children, className, icon }) => (
+  <motion.div variants={sectionItemVariants} className={`py-4 ${className || ''}`}>
+    <div className="flex items-center mb-3">
+      {icon && <span className="mr-2 text-theme-accent-primary">{icon}</span>}
+      <h4 className="font-display font-semibold text-theme-accent-primary text-lg">{title}</h4>
+    </div>
+    <div className="font-body space-y-3">{children}</div>
+  </motion.div>
+);
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -56,15 +74,15 @@ interface SettingsModalProps {
   onReducedMotionChange: (enabled: boolean) => void;
 }
 
-const SettingsModal: React.FC<SettingsModalProps> = ({ 
-    isOpen, 
-    onClose, 
-    addNotification,
-    currentTheme,
-    onThemeChange,
-    availableThemes,
-    prefersReducedMotion,
-    onReducedMotionChange,
+const SettingsModal: React.FC<SettingsModalProps> = ({
+  isOpen,
+  onClose,
+  addNotification,
+  currentTheme,
+  onThemeChange,
+  availableThemes,
+  prefersReducedMotion,
+  onReducedMotionChange,
 }) => {
   const [aiStatus, setAiStatus] = useState(false);
   const [testResult, setTestResult] = useState<string | null>(null);
@@ -73,7 +91,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [accentColor, setAccentColorState] = useState(Storage.getAccentColor());
-  const [fontSizeMultiplier, setFontSizeMultiplierState] = useState(Storage.getFontSizeMultiplier());
+  const [fontSizeMultiplier, setFontSizeMultiplierState] = useState(
+    Storage.getFontSizeMultiplier()
+  );
   const [highContrastMode, setHighContrastModeState] = useState(Storage.getHighContrastMode());
   const [listDensity, setListDensityState] = useState(Storage.getListDensity());
   const [themePreview, setThemePreview] = useState<ThemeName | 'auto'>(currentTheme);
@@ -81,9 +101,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       setAiStatus(Storage.isAiEnabled());
-      setTestResult(null); 
+      setTestResult(null);
       setShowWelcomeToggle(Storage.getShowWelcomeOnNextLaunchPreference());
-      
+
       setAccentColorState(Storage.getAccentColor());
       setFontSizeMultiplierState(Storage.getFontSizeMultiplier());
       setHighContrastModeState(Storage.getHighContrastMode());
@@ -103,28 +123,33 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   }, [isOpen, currentTheme, accentColor]);
 
   const handleClearAllData = () => {
-    if (window.confirm("CONFIRM: Delete ALL local data? This action is final and cannot be undone.")) {
-      localStorage.removeItem('IDEA_FORGE_LOCAL_PROJECTS'); 
-      addNotification("All local data has been deleted. The application will now reload.", 'success');
+    if (
+      window.confirm('CONFIRM: Delete ALL local data? This action is final and cannot be undone.')
+    ) {
+      localStorage.removeItem('IDEA_FORGE_LOCAL_PROJECTS');
+      addNotification(
+        'All local data has been deleted. The application will now reload.',
+        'success'
+      );
       onClose();
-      setTimeout(() => window.location.reload(), 1500); 
+      setTimeout(() => window.location.reload(), 1500);
     }
   };
 
   const handleTestAiConnection = async () => {
     setIsTestingAi(true);
-    setTestResult("Pinging AI Core...");
+    setTestResult('Pinging AI Core...');
     const result = await Storage.testAiConnection();
     if (result.success) {
-      setTestResult(`Connection successful! Response: "${result.data || "OK"}"`);
-      addNotification("AI Core connection test successful.", 'success');
+      setTestResult(`Connection successful! Response: "${result.data || 'OK'}"`);
+      addNotification('AI Core connection test successful.', 'success');
     } else {
       setTestResult(`Connection failed: ${result.message}`);
       addNotification(`AI Core connection failed: ${result.message}`, 'error');
     }
     setIsTestingAi(false);
   };
-  
+
   const handleDownloadAllData = () => {
     try {
       const jsonData = Storage.getAllProjectsAsJson();
@@ -138,10 +163,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
-      addNotification("Full data backup successfully downloaded.", 'success');
+      addNotification('Full data backup successfully downloaded.', 'success');
     } catch (error) {
-      addNotification("Data backup failed to initiate.", 'error');
-      console.error("Error downloading data:", error);
+      addNotification('Data backup failed to initiate.', 'error');
+      console.error('Error downloading data:', error);
     }
   };
 
@@ -162,18 +187,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
           addNotification(`Backup import failed: ${importResult.message}`, 'error');
         }
       } catch (error) {
-        addNotification(`Backup import failed: ${error instanceof Error ? error.message : String(error)}`, 'error');
+        addNotification(
+          `Backup import failed: ${error instanceof Error ? error.message : String(error)}`,
+          'error'
+        );
       }
     };
     reader.readAsText(file);
-    if(fileInputRef.current) fileInputRef.current.value = ""; 
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   const handleWelcomeToggleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const isChecked = e.target.checked;
     setShowWelcomeToggle(isChecked);
     Storage.setShowWelcomeOnNextLaunchPreference(isChecked);
-    addNotification(`Welcome screen will ${isChecked ? 'show' : 'be skipped'} on next launch.`, 'info');
+    addNotification(
+      `Welcome screen will ${isChecked ? 'show' : 'be skipped'} on next launch.`,
+      'info'
+    );
   };
 
   const handleAccentColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -215,7 +246,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
     Storage.setListDensity(newDensity);
     addNotification(`List view density set to ${newDensity}.`, 'info');
   };
-  
+
   const handleThemePreview = (theme: ThemeName | 'auto') => setThemePreview(theme);
   const handleThemeSelect = (theme: ThemeName | 'auto') => {
     if (theme === 'auto') {
@@ -226,31 +257,34 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
       onThemeChange(theme);
     }
   };
-  
+
   return (
-    <Modal 
-        isOpen={isOpen} 
-        onClose={onClose} 
-        title="Cosmic Control Center" 
-        size="xl"
-        isGlassmorphic
-        prefersReducedMotion={prefersReducedMotion}
-        className="!rounded-2xl shadow-2xl shadow-black/30"
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Cosmic Control Center"
+      size="xl"
+      isGlassmorphic
+      prefersReducedMotion={prefersReducedMotion}
+      className="!rounded-2xl shadow-2xl shadow-black/30"
     >
       <p className="text-sm text-theme-text-secondary mb-4 -mt-2">
-        Fine-tune your IdeaForge experience. Calibrate the interface, data protocols, and AI augments for peak creative flow.
+        Fine-tune your IdeaForge experience. Calibrate the interface, data protocols, and AI
+        augments for peak creative flow.
       </p>
-      <motion.div 
+      <motion.div
         variants={sectionContainerVariants}
         initial="hidden"
         animate="visible"
         className="space-y-1 divide-y divide-theme-border-primary/50 text-theme-text-primary text-sm max-h-[70vh] overflow-y-auto pr-2 custom-scrollbar"
       >
-        
-        <Section title="Interface & Theme" icon={<PaletteIcon className="w-5 h-5"/>}>
-          <SettingItem title="Active Theme" description="Select your preferred visual theme for the application.">
+        <Section title="Interface & Theme" icon={<PaletteIcon className="w-5 h-5" />}>
+          <SettingItem
+            title="Active Theme"
+            description="Select your preferred visual theme for the application."
+          >
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              {[...availableThemes, 'auto'].map(theme => (
+              {[...availableThemes, 'auto'].map((theme) => (
                 <button
                   key={theme}
                   type="button"
@@ -260,44 +294,74 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                   onClick={() => handleThemeSelect(theme as ThemeName | 'auto')}
                   aria-label={`Select ${theme} theme`}
                 >
-                  <div className="w-10 h-6 rounded mb-2 border border-theme-border-primary bg-gradient-to-r from-theme-bg-primary to-theme-bg-accent" style={{ boxShadow: theme === currentTheme ? '0 0 0 2px var(--color-accent-primary)' : undefined }} />
-                  <span className="capitalize text-xs font-body">{theme === 'auto' ? 'Auto' : theme}</span>
+                  <div
+                    className="w-10 h-6 rounded mb-2 border border-theme-border-primary bg-gradient-to-r from-theme-bg-primary to-theme-bg-accent"
+                    style={{
+                      boxShadow:
+                        theme === currentTheme
+                          ? '0 0 0 2px var(--color-accent-primary)'
+                          : undefined,
+                    }}
+                  />
+                  <span className="capitalize text-xs font-body">
+                    {theme === 'auto' ? 'Auto' : theme}
+                  </span>
                 </button>
               ))}
             </div>
           </SettingItem>
-          <SettingItem title="Accent Color" description="Manually override the primary accent color for the current theme.">
+          <SettingItem
+            title="Accent Color"
+            description="Manually override the primary accent color for the current theme."
+          >
             <div className="flex items-center space-x-3">
-              <input 
-                type="color" 
-                value={accentColor} 
+              <input
+                type="color"
+                value={accentColor}
                 onChange={handleAccentColorChange}
                 className="w-10 h-10 p-0 border-none rounded-lg cursor-pointer bg-theme-bg-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-accent focus-visible:ring-theme-accent-primary"
                 title="Select accent color"
               />
-              <div className="font-mono text-sm p-2 bg-theme-bg-accent rounded-md border border-theme-border-primary/50">{accentColor.toUpperCase()}</div>
-              <Button variant="ghost" size="sm" onClick={handleResetAccentColor} aria-label="Reset accent color">Reset</Button>
+              <div className="font-mono text-sm p-2 bg-theme-bg-accent rounded-md border border-theme-border-primary/50">
+                {accentColor.toUpperCase()}
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleResetAccentColor}
+                aria-label="Reset accent color"
+              >
+                Reset
+              </Button>
             </div>
           </SettingItem>
         </Section>
 
-        <Section title="Accessibility" icon={<AdjustmentsHorizontalIcon className="w-5 h-5"/>}>
-          <SettingItem title="Global Text Size" description="Adjust the base font size for all text in the application.">
+        <Section title="Accessibility" icon={<AdjustmentsHorizontalIcon className="w-5 h-5" />}>
+          <SettingItem
+            title="Global Text Size"
+            description="Adjust the base font size for all text in the application."
+          >
             <div className="flex items-center space-x-3">
-               <input 
-                type="range" 
-                min="0.8" 
-                max="1.3" 
-                step="0.05" 
-                value={fontSizeMultiplier} 
+              <input
+                type="range"
+                min="0.8"
+                max="1.3"
+                step="0.05"
+                value={fontSizeMultiplier}
                 onChange={handleFontSizeChange}
                 className="w-full h-2 bg-theme-bg-accent rounded-lg appearance-none cursor-pointer accent-theme-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-accent focus-visible:ring-theme-accent-primary"
               />
-              <span className="text-sm font-mono w-14 text-center p-1 bg-theme-bg-accent rounded-md border border-theme-border-primary/50">{Math.round(fontSizeMultiplier * 100)}%</span>
+              <span className="text-sm font-mono w-14 text-center p-1 bg-theme-bg-accent rounded-md border border-theme-border-primary/50">
+                {Math.round(fontSizeMultiplier * 100)}%
+              </span>
             </div>
           </SettingItem>
-          <SettingItem title="High-Contrast Mode" description="Increases text-to-background contrast for better legibility.">
-             <label htmlFor="highContrastToggle" className="flex items-center cursor-pointer">
+          <SettingItem
+            title="High-Contrast Mode"
+            description="Increases text-to-background contrast for better legibility."
+          >
+            <label htmlFor="highContrastToggle" className="flex items-center cursor-pointer">
               <input
                 type="checkbox"
                 id="highContrastToggle"
@@ -308,8 +372,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               Enable high-contrast mode
             </label>
           </SettingItem>
-          <SettingItem title="Reduce Animations" description="Disables or reduces UI motion for a calmer experience.">
-            <label htmlFor="reducedMotionToggleSettings" className="flex items-center cursor-pointer">
+          <SettingItem
+            title="Reduce Animations"
+            description="Disables or reduces UI motion for a calmer experience."
+          >
+            <label
+              htmlFor="reducedMotionToggleSettings"
+              className="flex items-center cursor-pointer"
+            >
               <input
                 type="checkbox"
                 id="reducedMotionToggleSettings"
@@ -322,70 +392,132 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
           </SettingItem>
         </Section>
 
-        <Section title="Layout & Density" icon={<SquaresPlusIcon className="w-5 h-5"/>}>
-           <SettingItem title="List View Density" description="Choose between more compact or spacious layouts for project and idea lists.">
-            <select 
-                value={listDensity}
-                onChange={handleListDensityChange}
-                className="w-full sm:w-2/3 p-2 rounded-lg bg-theme-bg-accent border border-theme-border-primary hover:border-theme-accent-primary focus:ring-2 focus:ring-theme-accent-primary focus:border-theme-accent-primary text-theme-text-primary font-body transition-colors"
+        <Section title="Layout & Density" icon={<SquaresPlusIcon className="w-5 h-5" />}>
+          <SettingItem
+            title="List View Density"
+            description="Choose between more compact or spacious layouts for project and idea lists."
+          >
+            <select
+              value={listDensity}
+              onChange={handleListDensityChange}
+              className="w-full sm:w-2/3 p-2 rounded-lg bg-theme-bg-accent border border-theme-border-primary hover:border-theme-accent-primary focus:ring-2 focus:ring-theme-accent-primary focus:border-theme-accent-primary text-theme-text-primary font-body transition-colors"
             >
-                <option value="spacious">Spacious Nebulae (Default)</option>
-                <option value="compact">Compact Clusters</option>
+              <option value="spacious">Spacious Nebulae (Default)</option>
+              <option value="compact">Compact Clusters</option>
             </select>
           </SettingItem>
         </Section>
-        
-        <Section title="System & Data" icon={<CogIcon className="w-5 h-5"/>} className="pt-6">
-            <SettingItem title="Welcome Screen" description="Control whether the welcome screen appears on application launch.">
-                <label htmlFor="showWelcomeToggleSystem" className="flex items-center cursor-pointer">
-                    <input
-                        type="checkbox"
-                        id="showWelcomeToggleSystem"
-                        checked={showWelcomeToggle}
-                        onChange={handleWelcomeToggleChange}
-                        className="h-4 w-4 shrink-0 rounded border-2 border-theme-border-primary bg-theme-bg-secondary text-theme-accent-primary focus:ring-2 focus:ring-theme-accent-primary focus:ring-offset-2 focus:ring-offset-theme-bg-secondary checked:bg-theme-accent-primary checked:border-transparent cursor-pointer mr-3"
-                    />
-                    Show on next launch
-                </label>
-            </SettingItem>
 
-            <SettingItem title="AI Core (Gemini)" description={
-                aiStatus
-                ? "AI features are online. (Requires a valid API key)"
-                : "AI features are offline. An API key is required."
-            }>
-                {aiStatus && (
-                    <div className="mt-2">
-                    <Button onClick={handleTestAiConnection} variant="outline" size="sm" disabled={isTestingAi} leftIcon={<SparklesIcon className={`w-4 h-4 ${isTestingAi ? 'animate-spin' : ''}`} />} prefersReducedMotion={prefersReducedMotion}>
-                        {isTestingAi ? 'Connecting...' : 'Test AI Connection'}
-                    </Button>
-                    {testResult && <p className={`text-xs mt-2 p-2 rounded ${testResult.startsWith("Connection successful") ? 'bg-status-success/10 text-status-success' : 'bg-status-error/10 text-status-error'}`}>{testResult}</p>}
-                    </div>
-                )}
-            </SettingItem>
+        <Section title="System & Data" icon={<CogIcon className="w-5 h-5" />} className="pt-6">
+          <SettingItem
+            title="Welcome Screen"
+            description="Control whether the welcome screen appears on application launch."
+          >
+            <label htmlFor="showWelcomeToggleSystem" className="flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                id="showWelcomeToggleSystem"
+                checked={showWelcomeToggle}
+                onChange={handleWelcomeToggleChange}
+                className="h-4 w-4 shrink-0 rounded border-2 border-theme-border-primary bg-theme-bg-secondary text-theme-accent-primary focus:ring-2 focus:ring-theme-accent-primary focus:ring-offset-2 focus:ring-offset-theme-bg-secondary checked:bg-theme-accent-primary checked:border-transparent cursor-pointer mr-3"
+              />
+              Show on next launch
+            </label>
+          </SettingItem>
 
-            <SettingItem title="Backup & Restore" description="Export all your projects and ideas to a JSON file, or restore from a previous backup.">
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <Button variant="outline" onClick={handleDownloadAllData} size="md" leftIcon={<ArrowDownTrayIcon className="w-5 h-5"/>} prefersReducedMotion={prefersReducedMotion}>
-                        Backup All Data
-                    </Button>
-                    <Button variant="outline" onClick={() => fileInputRef.current?.click()} size="md" leftIcon={<ArrowUpTrayIcon className="w-5 h-5"/>} prefersReducedMotion={prefersReducedMotion}>
-                        Import from Backup
-                    </Button>
-                    <input type="file" accept=".json" ref={fileInputRef} onChange={handleImportData} className="hidden" />
-                </div>
-            </SettingItem>
-
-            <SettingItem title="System Reset Protocol (Danger Zone)" description="Permanently delete all projects, ideas, and settings from this browser. This cannot be undone.">
-                 <Button variant="danger" onClick={handleClearAllData} size="md" leftIcon={<TrashIcon className="w-5 h-5"/>} prefersReducedMotion={prefersReducedMotion}>
-                    Delete All Local Data
+          <SettingItem
+            title="AI Core (Gemini)"
+            description={
+              aiStatus
+                ? 'AI features are online. (Requires a valid API key)'
+                : 'AI features are offline. An API key is required.'
+            }
+          >
+            {aiStatus && (
+              <div className="mt-2">
+                <Button
+                  onClick={handleTestAiConnection}
+                  variant="outline"
+                  size="sm"
+                  disabled={isTestingAi}
+                  leftIcon={
+                    <SparklesIcon className={`w-4 h-4 ${isTestingAi ? 'animate-spin' : ''}`} />
+                  }
+                  prefersReducedMotion={prefersReducedMotion}
+                >
+                  {isTestingAi ? 'Connecting...' : 'Test AI Connection'}
                 </Button>
-            </SettingItem>
+                {testResult && (
+                  <p
+                    className={`text-xs mt-2 p-2 rounded ${testResult.startsWith('Connection successful') ? 'bg-status-success/10 text-status-success' : 'bg-status-error/10 text-status-error'}`}
+                  >
+                    {testResult}
+                  </p>
+                )}
+              </div>
+            )}
+          </SettingItem>
+
+          <SettingItem
+            title="Backup & Restore"
+            description="Export all your projects and ideas to a JSON file, or restore from a previous backup."
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Button
+                variant="outline"
+                onClick={handleDownloadAllData}
+                size="md"
+                leftIcon={<ArrowDownTrayIcon className="w-5 h-5" />}
+                prefersReducedMotion={prefersReducedMotion}
+              >
+                Backup All Data
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+                size="md"
+                leftIcon={<ArrowUpTrayIcon className="w-5 h-5" />}
+                prefersReducedMotion={prefersReducedMotion}
+              >
+                Import from Backup
+              </Button>
+              <input
+                type="file"
+                accept=".json"
+                ref={fileInputRef}
+                onChange={handleImportData}
+                className="hidden"
+              />
+            </div>
+          </SettingItem>
+
+          <SettingItem
+            title="System Reset Protocol (Danger Zone)"
+            description="Permanently delete all projects, ideas, and settings from this browser. This cannot be undone."
+          >
+            <Button
+              variant="danger"
+              onClick={handleClearAllData}
+              size="md"
+              leftIcon={<TrashIcon className="w-5 h-5" />}
+              prefersReducedMotion={prefersReducedMotion}
+            >
+              Delete All Local Data
+            </Button>
+          </SettingItem>
         </Section>
 
-        <Section title="Design Tokens" icon={<CogIcon className="w-5 h-5"/>}>
+        <Section title="Design Tokens" icon={<CogIcon className="w-5 h-5" />}>
           <SettingItem title="Spacing" description="Adjust base spacing for UI elements.">
-            <input type="range" min="0.5" max="2" step="0.05" value={1} className="w-full" disabled />
+            <input
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.05"
+              value={1}
+              className="w-full"
+              disabled
+            />
             <span className="text-xs text-theme-text-secondary">(Coming soon)</span>
           </SettingItem>
           <SettingItem title="Typography" description="Choose font family and scale.">
@@ -394,7 +526,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             </select>
             <span className="text-xs text-theme-text-secondary">(Coming soon)</span>
           </SettingItem>
-          <SettingItem title="Animation Curve" description="Set the animation curve for transitions.">
+          <SettingItem
+            title="Animation Curve"
+            description="Set the animation curve for transitions."
+          >
             <select className="w-full" disabled>
               <option>ease-in-out</option>
             </select>
@@ -403,7 +538,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
         </Section>
       </motion.div>
       <footer className="mt-8 flex justify-end">
-        <Button variant="default" onClick={onClose} size="lg" prefersReducedMotion={prefersReducedMotion}>Apply & Close</Button>
+        <Button
+          variant="default"
+          onClick={onClose}
+          size="lg"
+          prefersReducedMotion={prefersReducedMotion}
+        >
+          Apply & Close
+        </Button>
       </footer>
     </Modal>
   );

--- a/components/TextArea.tsx
+++ b/components/TextArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { QuestionMarkCircleIcon } from './icons'; 
+import { QuestionMarkCircleIcon } from './icons';
 
 interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
@@ -8,33 +8,47 @@ interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement
   wrapperClassName?: string;
 }
 
-const TextArea: React.FC<TextAreaProps> = ({ label, id, error, className, helpText, wrapperClassName, ...props }) => (
-    <div className={`w-full ${wrapperClassName || ''}`}>
-      {label && (
-         <div className="flex items-center mb-1.5">
-          <label htmlFor={id} className="block text-sm font-medium text-theme-text-secondary font-sans">{label}</label>
-          {helpText && (
-            <div className="help-tooltip-wrapper ml-1.5">
-              <QuestionMarkCircleIcon className="w-4 h-4 text-theme-accent-primary help-tooltip-icon" />
-              <span className="help-tooltip-text">{helpText}</span> {/* Tooltip text styled globally */}
-            </div>
-          )}
-        </div>
-      )}
-      <textarea
-        id={id}
-        rows={props.rows || 4}
-        className={`block w-full px-3 py-2 bg-theme-bg-accent border border-theme-border-primary rounded-lg shadow-sm placeholder:text-theme-text-secondary 
+const TextArea: React.FC<TextAreaProps> = ({
+  label,
+  id,
+  error,
+  className,
+  helpText,
+  wrapperClassName,
+  ...props
+}) => (
+  <div className={`w-full ${wrapperClassName || ''}`}>
+    {label && (
+      <div className="flex items-center mb-1.5">
+        <label
+          htmlFor={id}
+          className="block text-sm font-medium text-theme-text-secondary font-sans"
+        >
+          {label}
+        </label>
+        {helpText && (
+          <div className="help-tooltip-wrapper ml-1.5">
+            <QuestionMarkCircleIcon className="w-4 h-4 text-theme-accent-primary help-tooltip-icon" />
+            <span className="help-tooltip-text">{helpText}</span>{' '}
+            {/* Tooltip text styled globally */}
+          </div>
+        )}
+      </div>
+    )}
+    <textarea
+      id={id}
+      rows={props.rows || 4}
+      className={`block w-full px-3 py-2 bg-theme-bg-accent border border-theme-border-primary rounded-lg shadow-sm placeholder:text-theme-text-secondary 
                     focus:outline-none focus:ring-1 focus:ring-theme-accent-primary focus:border-theme-accent-primary 
                     text-theme-text-primary font-body text-sm
                     disabled:bg-theme-bg-secondary/50 disabled:text-theme-text-secondary/70 disabled:cursor-not-allowed
                     transition-colors duration-150
                     ${error ? 'border-status-error focus:ring-status-error focus:border-status-error' : 'border-theme-border-primary hover:border-theme-accent-primary/50'} 
                     ${className || ''}`}
-        {...props}
-      />
-      {error && <p className="mt-1 text-xs text-status-error font-sans">{error}</p>}
-    </div>
-  );
+      {...props}
+    />
+    {error && <p className="mt-1 text-xs text-status-error font-sans">{error}</p>}
+  </div>
+);
 
 export default TextArea;

--- a/components/TextInput.tsx
+++ b/components/TextInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { QuestionMarkCircleIcon } from './icons'; 
+import { QuestionMarkCircleIcon } from './icons';
 
 interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -8,32 +8,46 @@ interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   wrapperClassName?: string;
 }
 
-const TextInput: React.FC<TextInputProps> = ({ label, id, error, className, helpText, wrapperClassName, ...props }) => (
-    <div className={`w-full ${wrapperClassName || ''}`}>
-      {label && (
-        <div className="flex items-center mb-1.5">
-          <label htmlFor={id} className="block text-sm font-medium text-theme-text-secondary font-sans">{label}</label> 
-          {helpText && (
-            <div className="help-tooltip-wrapper ml-1.5">
-              <QuestionMarkCircleIcon className="w-4 h-4 text-theme-accent-primary help-tooltip-icon" />
-              <span className="help-tooltip-text">{helpText}</span> {/* Tooltip text styled globally */}
-            </div>
-          )}
-        </div>
-      )}
-      <input
-        id={id}
-        className={`block w-full px-3 py-2 bg-theme-bg-accent border border-theme-border-primary rounded-lg shadow-sm placeholder:text-theme-text-secondary 
+const TextInput: React.FC<TextInputProps> = ({
+  label,
+  id,
+  error,
+  className,
+  helpText,
+  wrapperClassName,
+  ...props
+}) => (
+  <div className={`w-full ${wrapperClassName || ''}`}>
+    {label && (
+      <div className="flex items-center mb-1.5">
+        <label
+          htmlFor={id}
+          className="block text-sm font-medium text-theme-text-secondary font-sans"
+        >
+          {label}
+        </label>
+        {helpText && (
+          <div className="help-tooltip-wrapper ml-1.5">
+            <QuestionMarkCircleIcon className="w-4 h-4 text-theme-accent-primary help-tooltip-icon" />
+            <span className="help-tooltip-text">{helpText}</span>{' '}
+            {/* Tooltip text styled globally */}
+          </div>
+        )}
+      </div>
+    )}
+    <input
+      id={id}
+      className={`block w-full px-3 py-2 bg-theme-bg-accent border border-theme-border-primary rounded-lg shadow-sm placeholder:text-theme-text-secondary 
                     focus:outline-none focus:ring-1 focus:ring-theme-accent-primary focus:border-theme-accent-primary 
                     text-theme-text-primary font-body text-sm
                     disabled:bg-theme-bg-secondary/50 disabled:text-theme-text-secondary/70 disabled:cursor-not-allowed
                     transition-colors duration-150
                     ${error ? 'border-status-error focus:ring-status-error focus:border-status-error' : 'border-theme-border-primary hover:border-theme-accent-primary/50'} 
                     ${className || ''}`}
-        {...props}
-      />
-      {error && <p className="mt-1 text-xs text-status-error font-sans">{error}</p>}
-    </div>
-  );
+      {...props}
+    />
+    {error && <p className="mt-1 text-xs text-status-error font-sans">{error}</p>}
+  </div>
+);
 
 export default TextInput;

--- a/components/WelcomeScreen.tsx
+++ b/components/WelcomeScreen.tsx
@@ -1,99 +1,105 @@
 // components/WelcomeScreen.tsx
 import React from 'react';
 import { motion } from 'framer-motion';
-import RippleButton from './RippleButton'; 
-import { slideDown, staggerContainer, staggerItem } from '../motion/variants'; 
+import RippleButton from './RippleButton';
+import { slideDown, staggerContainer, staggerItem } from '../motion/variants';
 import { PlusCircleIcon, SparklesIcon } from './icons';
 
 interface WelcomeScreenProps {
-  onGetStarted: () => void; 
+  onGetStarted: () => void;
   onImportSample: () => void;
 }
 
 const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onGetStarted, onImportSample }) => {
-
   const handleTryDemo = () => {
     onImportSample(); // This usually adds a notification
     // Potentially delay onGetStarted to allow notification to be seen, or rely on App.tsx flow
-    onGetStarted(); 
+    onGetStarted();
   };
-  
+
   return (
-      <motion.section
-        className="fixed inset-0 z-10 flex flex-col items-center justify-center p-space-sm sm:p-space-md text-center"
-        variants={slideDown} 
+    <motion.section
+      className="fixed inset-0 z-10 flex flex-col items-center justify-center p-space-sm sm:p-space-md text-center"
+      variants={slideDown}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      aria-labelledby="welcome-heading"
+    >
+      <motion.div
+        variants={staggerContainer} // Use stagger for inner elements
         initial="hidden"
         animate="visible"
-        exit="exit" 
-        aria-labelledby="welcome-heading"
+        className="w-full max-w-lg xl:max-w-xl relative glassmorphic p-6 sm:p-8 md:p-10 rounded-xl shadow-2xl border border-theme-border-accent/30"
       >
-        <motion.div 
-          variants={staggerContainer} // Use stagger for inner elements
-          initial="hidden"
-          animate="visible"
-          className="w-full max-w-lg xl:max-w-xl relative glassmorphic p-6 sm:p-8 md:p-10 rounded-xl shadow-2xl border border-theme-border-accent/30"
-        >
-          <motion.div variants={staggerItem} className="mb-4 sm:mb-6">
-            <img src="assets/images/logo.png" alt="IdeaForge Logo" className="w-36 h-auto sm:w-48 mx-auto filter drop-shadow-[0_0_15px_var(--color-accent-primary)]" />
-          </motion.div>
-          
-          <motion.h1 
-            id="welcome-heading" 
-            variants={staggerItem}
-            className="text-3xl sm:text-4xl md:text-5xl font-display font-bold text-theme-text-primary mb-2 sm:mb-3 uppercase tracking-[0.1em] sm:tracking-[0.15em]"
-            style={{ textShadow: '0 0 8px var(--color-accent-primary), 0 0 15px var(--color-accent-secondary)' }}
-          >
-            WELCOME TO IDEAFORGE
-          </motion.h1>
-          
-          <motion.p 
-            variants={staggerItem}
-            className="text-lg sm:text-xl font-body text-theme-accent-primary font-semibold mb-4 sm:mb-6"
-          >
-            Think freely. Build clearly.
-          </motion.p>
-
-          <motion.p 
-            variants={staggerItem}
-            className="text-sm sm:text-base text-theme-text-primary mb-6 sm:mb-8 font-body leading-relaxed max-w-md mx-auto"
-          >
-            A distraction-free environment for building connected thoughts, diagrams, and designs.
-          </motion.p>
-
-          <motion.div 
-            variants={staggerItem}
-            className="space-y-3 sm:space-y-0 sm:flex sm:justify-center sm:space-x-4"
-          >
-            <RippleButton 
-                onClick={handleTryDemo} 
-                variant="outline" 
-                size="lg" 
-                className="w-full sm:w-auto"
-                aria-label="Try a demo project and enter the application"
-                leftIcon={<PlusCircleIcon className="w-5 h-5" />}
-            >
-              Try Demo
-            </RippleButton>
-            <RippleButton 
-                onClick={onGetStarted} 
-                variant="glow" 
-                size="lg" 
-                className="w-full sm:w-auto"
-                aria-label="Enter the main application"
-                leftIcon={<SparklesIcon className="w-5 h-5"/>}
-            >
-             Enter the Forge
-            </RippleButton>
-          </motion.div>
-
-          <motion.p 
-            variants={staggerItem}
-            className="text-xs text-theme-text-secondary/80 mt-8 sm:mt-10 font-mono tracking-widest"
-          >
-            // YOUR COSMIC FORGE AWAITS //
-          </motion.p>
+        <motion.div variants={staggerItem} className="mb-4 sm:mb-6">
+          <img
+            src="assets/images/logo.png"
+            alt="IdeaForge Logo"
+            className="w-36 h-auto sm:w-48 mx-auto filter drop-shadow-[0_0_15px_var(--color-accent-primary)]"
+          />
         </motion.div>
-      </motion.section>
+
+        <motion.h1
+          id="welcome-heading"
+          variants={staggerItem}
+          className="text-3xl sm:text-4xl md:text-5xl font-display font-bold text-theme-text-primary mb-2 sm:mb-3 uppercase tracking-[0.1em] sm:tracking-[0.15em]"
+          style={{
+            textShadow:
+              '0 0 8px var(--color-accent-primary), 0 0 15px var(--color-accent-secondary)',
+          }}
+        >
+          WELCOME TO IDEAFORGE
+        </motion.h1>
+
+        <motion.p
+          variants={staggerItem}
+          className="text-lg sm:text-xl font-body text-theme-accent-primary font-semibold mb-4 sm:mb-6"
+        >
+          Think freely. Build clearly.
+        </motion.p>
+
+        <motion.p
+          variants={staggerItem}
+          className="text-sm sm:text-base text-theme-text-primary mb-6 sm:mb-8 font-body leading-relaxed max-w-md mx-auto"
+        >
+          A distraction-free environment for building connected thoughts, diagrams, and designs.
+        </motion.p>
+
+        <motion.div
+          variants={staggerItem}
+          className="space-y-3 sm:space-y-0 sm:flex sm:justify-center sm:space-x-4"
+        >
+          <RippleButton
+            onClick={handleTryDemo}
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto"
+            aria-label="Try a demo project and enter the application"
+            leftIcon={<PlusCircleIcon className="w-5 h-5" />}
+          >
+            Try Demo
+          </RippleButton>
+          <RippleButton
+            onClick={onGetStarted}
+            variant="glow"
+            size="lg"
+            className="w-full sm:w-auto"
+            aria-label="Enter the main application"
+            leftIcon={<SparklesIcon className="w-5 h-5" />}
+          >
+            Enter the Forge
+          </RippleButton>
+        </motion.div>
+
+        <motion.p
+          variants={staggerItem}
+          className="text-xs text-theme-text-secondary/80 mt-8 sm:mt-10 font-mono tracking-widest"
+        >
+          // YOUR COSMIC FORGE AWAITS //
+        </motion.p>
+      </motion.div>
+    </motion.section>
   );
 };
 

--- a/components/Workbench.tsx
+++ b/components/Workbench.tsx
@@ -15,18 +15,27 @@ interface WorkbenchProps {
   onCreateProject: (projectName: string) => void;
   onDeleteProject: (projectId: string) => void;
   addNotification: (message: string, type: 'success' | 'error' | 'info') => void;
-  onQuickNewIdea: (project: Project) => void; 
+  onQuickNewIdea: (project: Project) => void;
 }
 
-const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCreateProject, onDeleteProject, addNotification, onQuickNewIdea }) => {
+const Workbench: React.FC<WorkbenchProps> = ({
+  projects,
+  onProjectSelected,
+  onCreateProject,
+  onDeleteProject,
+  addNotification,
+  onQuickNewIdea,
+}) => {
   const [newProjectName, setNewProjectName] = useState('');
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
 
-  const filteredProjects = useMemo(() => projects.filter(project =>
-      project.name.toLowerCase().includes(searchTerm.toLowerCase())
-    ), [projects, searchTerm]);
+  const filteredProjects = useMemo(
+    () =>
+      projects.filter((project) => project.name.toLowerCase().includes(searchTerm.toLowerCase())),
+    [projects, searchTerm]
+  );
 
   // Memoize handlers to avoid unnecessary re-renders
   const handleCreateProject = useCallback(() => {
@@ -59,9 +68,9 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
     // Assuming there's a prop method for toggling favorite as well
     // onToggleFavorite(projectId);
   };
-  
+
   return (
-    <motion.div 
+    <motion.div
       className="p-4 sm:p-6 md:p-8 w-full max-w-5xl mx-auto"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -72,21 +81,21 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
         <h1 className="text-3xl sm:text-4xl font-sans font-bold text-theme-accent-primary mb-3 sm:mb-0">
           Constellation Navigator
         </h1>
-        <Button 
+        <Button
           onClick={() => {
-            setNewProjectName(''); 
+            setNewProjectName('');
             setIsCreateModalOpen(true);
-          }} 
-          variant="default" 
+          }}
+          variant="default"
           size="lg"
-          leftIcon={<PlusCircleIcon className="w-5 h-5"/>}
+          leftIcon={<PlusCircleIcon className="w-5 h-5" />}
           title="Begin charting a new constellation."
           aria-label="Create new constellation"
         >
           New Constellation
         </Button>
       </div>
-      
+
       <div className="mb-6 sm:mb-8">
         <TextInput
           placeholder="Search constellations..."
@@ -99,13 +108,13 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
 
       <AnimatePresence>
         {filteredProjects.length > 0 ? (
-          <motion.ul 
+          <motion.ul
             className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6"
             variants={staggerContainer}
             initial="hidden"
             animate="visible"
           >
-            {filteredProjects.map(project => (
+            {filteredProjects.map((project) => (
               <motion.li key={project.id} variants={staggerItem}>
                 <BlueprintCard
                   item={project}
@@ -119,12 +128,14 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
             ))}
           </motion.ul>
         ) : (
-          <motion.p 
+          <motion.p
             className="text-center text-theme-text-secondary py-10 font-sans"
             initial={{ opacity: 0 }}
-            animate={{ opacity: 1, transition: {delay: 0.2} }}
+            animate={{ opacity: 1, transition: { delay: 0.2 } }}
           >
-            {searchTerm ? "No constellations match your cosmic query." : "Your forge is quiet, star-smith. Ready to ignite your first constellation?"}
+            {searchTerm
+              ? 'No constellations match your cosmic query.'
+              : 'Your forge is quiet, star-smith. Ready to ignite your first constellation?'}
           </motion.p>
         )}
       </AnimatePresence>
@@ -136,11 +147,13 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
       >
         {projects.length > 0 && (
           <div className="mb-6">
-            <h4 className="text-md font-sans font-medium text-theme-accent-primary mb-2">Navigate Existing Constellations</h4>
+            <h4 className="text-md font-sans font-medium text-theme-accent-primary mb-2">
+              Navigate Existing Constellations
+            </h4>
             <ul className="max-h-40 overflow-y-auto space-y-2 pr-1 custom-scrollbar">
-              {projects.map(p => (
-                <li 
-                  key={p.id} 
+              {projects.map((p) => (
+                <li
+                  key={p.id}
                   className="text-theme-text-primary hover:text-theme-accent-primary p-2.5 bg-theme-bg-accent/70 hover:bg-theme-bg-accent rounded-lg cursor-pointer transition-colors duration-150 flex justify-between items-center font-body"
                   onClick={() => {
                     onProjectSelected(p);
@@ -148,17 +161,31 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
                   }}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { onProjectSelected(p); setIsCreateModalOpen(false);}}}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      onProjectSelected(p);
+                      setIsCreateModalOpen(false);
+                    }
+                  }}
                 >
                   <div className="flex items-center space-x-2 truncate">
                     {p.logo ? (
-                      <img src={p.logo} alt="" className="w-6 h-6 object-cover rounded-sm flex-shrink-0 border border-theme-accent-primary/20" />
+                      <img
+                        src={p.logo}
+                        alt=""
+                        className="w-6 h-6 object-cover rounded-sm flex-shrink-0 border border-theme-accent-primary/20"
+                      />
                     ) : (
                       <DocumentTextIcon className="w-6 h-6 text-theme-accent-primary/50 flex-shrink-0" />
                     )}
                     <span className="truncate">{p.name}</span>
                   </div>
-                  {p.isFavorite && <StarIcon className="w-4 h-4 text-theme-accent-primary flex-shrink-0" isFilled />}
+                  {p.isFavorite && (
+                    <StarIcon
+                      className="w-4 h-4 text-theme-accent-primary flex-shrink-0"
+                      isFilled
+                    />
+                  )}
                 </li>
               ))}
             </ul>
@@ -167,22 +194,30 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
         )}
         <div>
           <h4 className="text-md font-sans font-medium text-theme-accent-primary mb-2">
-            {projects.length > 0 ? "Or Ignite a New Constellation" : "Ignite Your First Constellation"}
+            {projects.length > 0
+              ? 'Or Ignite a New Constellation'
+              : 'Ignite Your First Constellation'}
           </h4>
           <TextInput
             label="Constellation Name"
             value={newProjectName}
             onChange={(e) => setNewProjectName(e.target.value)}
             placeholder="e.g., Nova Navigator App"
-            autoFocus={projects.length === 0} 
-            onKeyDown={(e) => { if (e.key === 'Enter' && newProjectName.trim() !== '') { handleCreateProject();}}}
+            autoFocus={projects.length === 0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && newProjectName.trim() !== '') {
+                handleCreateProject();
+              }
+            }}
           />
         </div>
         <div className="mt-6 flex justify-end space-x-3">
-          <Button variant="ghost" onClick={() => setIsCreateModalOpen(false)}>Cancel</Button>
-          <Button 
-            variant="default" 
-            onClick={handleCreateProject} 
+          <Button variant="ghost" onClick={() => setIsCreateModalOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="default"
+            onClick={handleCreateProject}
             disabled={newProjectName.trim() === ''}
           >
             Create
@@ -195,10 +230,17 @@ const Workbench: React.FC<WorkbenchProps> = ({ projects, onProjectSelected, onCr
         onClose={() => setProjectToDelete(null)}
         title={`Dissolve Constellation "${projectToDelete?.name}"?`}
       >
-        <p className="text-theme-text-primary">This constellation and all its blueprints will fade into cosmic dust. This action is irreversible.</p>
+        <p className="text-theme-text-primary">
+          This constellation and all its blueprints will fade into cosmic dust. This action is
+          irreversible.
+        </p>
         <div className="mt-6 flex justify-end space-x-3">
-          <Button variant="ghost" onClick={() => setProjectToDelete(null)}>Cancel</Button>
-          <Button variant="danger" onClick={handleDeleteProject}>Delete Constellation</Button>
+          <Button variant="ghost" onClick={() => setProjectToDelete(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleDeleteProject}>
+            Delete Constellation
+          </Button>
         </div>
       </Modal>
     </motion.div>

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -6,246 +6,705 @@ type IconProps = React.SVGProps<SVGSVGElement> & { isFilled?: boolean };
 // Ensure all stroke and fill attributes are set to "currentColor" or handled by props for theming
 
 export const StarIcon: React.FC<IconProps> = ({ isFilled, className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" 
-       fill={isFilled ? "currentColor" : "none"} className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.82.61l-4.725-2.885a.562.562 0 0 0-.652 0l-4.725 2.885a.562.562 0 0 1-.82-.61l1.285-5.385a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    fill={isFilled ? 'currentColor' : 'none'}
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.82.61l-4.725-2.885a.562.562 0 0 0-.652 0l-4.725 2.885a.562.562 0 0 1-.82-.61l1.285-5.385a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+    />
   </svg>
 );
 
 export const EyeIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
+    />
     <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
   </svg>
 );
 
 export const EyeSlashIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 01-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L6.228 6.228" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 01-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L6.228 6.228"
+    />
   </svg>
 );
 
-
 export const EyeIconSolid: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
     <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
-    <path fillRule="evenodd" d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 0 1 0-1.113ZM17.25 12a5.25 5.25 0 1 1-10.5 0 5.25 5.25 0 0 1 10.5 0Z" clipRule="evenodd" />
+    <path
+      fillRule="evenodd"
+      d="M1.323 11.447C2.811 6.976 7.028 3.75 12.001 3.75c4.97 0 9.185 3.223 10.675 7.69.12.362.12.752 0 1.113-1.487 4.471-5.705 7.697-10.677 7.697-4.97 0-9.186-3.223-10.675-7.69a1.762 1.762 0 0 1 0-1.113ZM17.25 12a5.25 5.25 0 1 1-10.5 0 5.25 5.25 0 0 1 10.5 0Z"
+      clipRule="evenodd"
+    />
   </svg>
 );
 
 export const PencilIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
+    />
   </svg>
 );
 
 export const QuestionMarkCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
+    />
   </svg>
 );
 
 export const SparklesIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L1.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.25 7.5l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L25 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09L18.25 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L11.5 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L18.25 7.5Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L1.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.25 7.5l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L25 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09L18.25 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L11.5 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L18.25 7.5Z"
+    />
   </svg>
 );
 
 export const ArrowDownTrayIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+    />
   </svg>
 );
 
 export const ArrowUpTrayIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m0 0V12m0 0a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 12m0 0V9" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 12L12 3m0 0l-3.75 3.75M12 3l3.75 3.75" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m0 0V12m0 0a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 12m0 0V9"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 12L12 3m0 0l-3.75 3.75M12 3l3.75 3.75"
+    />
   </svg>
 );
 
 export const PlusCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
   </svg>
 );
 
 export const DocumentDuplicateIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376H3.375M15.75 17.25H18v-9.75A2.25 2.25 0 0 0 15.75 5.25H5.25A2.25 2.25 0 0 0 3 7.5v9.75a2.25 2.25 0 0 0 2.25 2.25h9.75a2.25 2.25 0 0 0 2.25-2.25Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376H3.375M15.75 17.25H18v-9.75A2.25 2.25 0 0 0 15.75 5.25H5.25A2.25 2.25 0 0 0 3 7.5v9.75a2.25 2.25 0 0 0 2.25 2.25h9.75a2.25 2.25 0 0 0 2.25-2.25Z"
+    />
   </svg>
 );
 
 export const CogIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93s.844.17 1.25.07l.894-.149c.542-.09.94-.56.94-1.11v-1.094c0-.55-.398-1.02-.94-1.11l-.894-.149a2.25 2.25 0 0 0-1.25.07c-.396.166-.71.506-.78.93L12 3l-.149.894a2.25 2.25 0 0 1-.78.93c-.406.17-.844.17-1.25.07l-.894-.149c-.542-.09-.94-.56-.94-1.11V1.75c0-.55.398-1.02.94-1.11l.894-.149a2.25 2.25 0 0 1 1.25.07c.396.166.71.506.78.93l.149.894c.09.542.56.94 1.11-.94h1.093c.55 0 1.02-.398 1.11-.94l.149.894c.07.424.384.764.78.93s.844.17 1.25.07l.894.149c.542.09.94.56.94 1.11v1.094c0 .55-.398-1.02-.94-1.11l-.894.149a2.25 2.25 0 0 0-1.25-.07c-.396-.166-.71-.506-.78-.93L12 21l.149-.894a2.25 2.25 0 0 1 .78-.93c.406-.17.844.17 1.25-.07l.894.149c.542.09.94.56.94 1.11v1.094c0 .55.398 1.02.94 1.11l.894.149a2.25 2.25 0 0 0 1.25-.07c.396.166.71-.506.78-.93l.149-.894c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02-.398 1.11-.94l.149.894c.07.424.384.764.78.93s.844.17 1.25.07l.894-.149c.542-.09.94-.56.94-1.11v-1.094c0-.55-.398-1.02-.94-1.11l-.894-.149a2.25 2.25 0 0 0-1.25.07c-.396-.166-.71-.506-.78-.93L13.657 3.94a2.25 2.25 0 0 0-3.314 0z" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93s.844.17 1.25.07l.894-.149c.542-.09.94-.56.94-1.11v-1.094c0-.55-.398-1.02-.94-1.11l-.894-.149a2.25 2.25 0 0 0-1.25.07c-.396.166-.71.506-.78.93L12 3l-.149.894a2.25 2.25 0 0 1-.78.93c-.406.17-.844.17-1.25.07l-.894-.149c-.542-.09-.94-.56-.94-1.11V1.75c0-.55.398-1.02.94-1.11l.894-.149a2.25 2.25 0 0 1 1.25.07c.396.166.71.506.78.93l.149.894c.09.542.56.94 1.11-.94h1.093c.55 0 1.02-.398 1.11-.94l.149.894c.07.424.384.764.78.93s.844.17 1.25.07l.894.149c.542.09.94.56.94 1.11v1.094c0 .55-.398-1.02-.94-1.11l-.894.149a2.25 2.25 0 0 0-1.25-.07c-.396-.166-.71-.506-.78-.93L12 21l.149-.894a2.25 2.25 0 0 1 .78-.93c.406-.17.844.17 1.25-.07l.894.149c.542.09.94.56.94 1.11v1.094c0 .55.398 1.02.94 1.11l.894.149a2.25 2.25 0 0 0 1.25-.07c.396.166.71-.506.78-.93l.149-.894c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02-.398 1.11-.94l.149.894c.07.424.384.764.78.93s.844.17 1.25.07l.894-.149c.542-.09.94-.56.94-1.11v-1.094c0-.55-.398-1.02-.94-1.11l-.894-.149a2.25 2.25 0 0 0-1.25.07c-.396-.166-.71-.506-.78-.93L13.657 3.94a2.25 2.25 0 0 0-3.314 0z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+    />
   </svg>
 );
 
 export const XMarkIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
   </svg>
 );
 
 export const CheckCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
   </svg>
 );
 
 export const ExclamationTriangleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+    />
   </svg>
 );
 
 export const InformationCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
+    />
   </svg>
 );
 
 export const ArrowLeftIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
     <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
   </svg>
 );
 
 export const DocumentTextIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
   </svg>
 );
 
 export const PhotoIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+    />
   </svg>
 );
 
 export const DocumentIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25M9 17.25h6M9 13.5h6M9 9.75h6.375M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25M9 17.25h6M9 13.5h6M9 9.75h6.375M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
   </svg>
 );
 
 export const DocumentArrowDownIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125V5.25A2.25 2.25 0 0 0 11.25 3H6.75A2.25 2.25 0 0 0 4.5 5.25v13.5A2.25 2.25 0 0 0 6.75 21h10.5A2.25 2.25 0 0 0 19.5 18.75V16.5M12 16.5V9.75m0 0L9.75 12M12 9.75l2.25 2.25m-3-6.75h6.75" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125V5.25A2.25 2.25 0 0 0 11.25 3H6.75A2.25 2.25 0 0 0 4.5 5.25v13.5A2.25 2.25 0 0 0 6.75 21h10.5A2.25 2.25 0 0 0 19.5 18.75V16.5M12 16.5V9.75m0 0L9.75 12M12 9.75l2.25 2.25m-3-6.75h6.75"
+    />
   </svg>
 );
 
 export const TrashIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12.56 0c1.153 0 2.243.032 3.223.094M7.5 5.25V3.75c0-.621.504-1.125 1.125-1.125h.375c.621 0 1.125.504 1.125 1.125v1.5m3.75 0V3.75c0-.621.504-1.125 1.125-1.125h.375c.621 0 1.125.504 1.125 1.125v1.5m-9.75 0h14.25" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12.56 0c1.153 0 2.243.032 3.223.094M7.5 5.25V3.75c0-.621.504-1.125 1.125-1.125h.375c.621 0 1.125.504 1.125 1.125v1.5m3.75 0V3.75c0-.621.504-1.125 1.125-1.125h.375c.621 0 1.125.504 1.125 1.125v1.5m-9.75 0h14.25"
+    />
   </svg>
 );
 
 export const PaperAirplaneIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"
+    />
   </svg>
 );
 
 // Added Icons for SettingsModal & App
 export const UserCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+    />
   </svg>
 );
 
 export const LockClosedIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
+    />
   </svg>
 );
 
 export const AdjustmentsHorizontalIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75"
+    />
   </svg>
 );
 
 export const ViewfinderCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
- <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.042 21.375A9.375 9.375 0 0 1 12 21.75c-2.066 0-3.999-.616-5.617-1.671m11.234-11.234a9.375 9.375 0 1 0-11.234 11.234m11.234-11.234c.162.247.311.504.446.768M2.25 12h3M12 2.25v3m6.75 6.75h3M12 18.75v3" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 12.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.042 21.375A9.375 9.375 0 0 1 12 21.75c-2.066 0-3.999-.616-5.617-1.671m11.234-11.234a9.375 9.375 0 1 0-11.234 11.234m11.234-11.234c.162.247.311.504.446.768M2.25 12h3M12 2.25v3m6.75 6.75h3M12 18.75v3"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 12.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+    />
   </svg>
 );
 
 export const SunIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+    />
   </svg>
 );
 
 export const MoonIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"
+    />
   </svg>
 );
 
-
 export const StopCircleIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
     <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9.563C9 9.254 9.254 9 9.563 9h4.874c.309 0 .563.254.563.563v4.874c0 .309-.254.563-.563.563H9.563A.562.562 0 0 1 9 14.437V9.564Z" />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 9.563C9 9.254 9.254 9 9.563 9h4.874c.309 0 .563.254.563.563v4.874c0 .309-.254.563-.563.563H9.563A.562.562 0 0 1 9 14.437V9.564Z"
+    />
   </svg>
 );
 
 export const SquaresPlusIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25v-2.25Z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6Z"
+    />
     <path strokeLinecap="round" strokeLinejoin="round" d="M15 15.75h4.5m-2.25-2.25v4.5" />
   </svg>
 );
 
 export const PaperClipIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.687 7.687a1.5 1.5 0 0 0 2.122 2.122l7.687-7.687-2.122-2.122Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.687 7.687a1.5 1.5 0 0 0 2.122 2.122l7.687-7.687-2.122-2.122Z"
+    />
   </svg>
 );
 
 export const ChevronDownIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
     <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
   </svg>
 );
 
 export const ChevronUpIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
     <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
   </svg>
 );
 
 export const PaletteIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.158-.158.34-.22.53-.22h.091l.752-.075c.225-.022.416.035.56.179l1.815 1.815c.144.144.197.335.179.56l-.075.752h.091c.19 0 .372.062.53.22l2.88 2.88M10.5 8.197c.246 0 .47.07.662.191m-6.401 6.402l6.401-6.402" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.158-.158.34-.22.53-.22h.091l.752-.075c.225-.022.416.035.56.179l1.815 1.815c.144.144.197.335.179.56l-.075.752h.091c.19 0 .372.062.53.22l2.88 2.88M10.5 8.197c.246 0 .47.07.662.191m-6.401 6.402l6.401-6.402"
+    />
   </svg>
 );
 
 export const EnvelopeIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+    />
   </svg>
 );
 
 export const RocketLaunchIcon: React.FC<IconProps> = ({ className, ...props }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.82m5.84-2.56v4.82a6 6 0 0 1-1.89-.88M16.532 8.732a6.003 6.003 0 0 1-7.381 5.84m7.381-5.84a6.003 6.003 0 0 0-4.16-2.92m4.16 2.92a6.003 6.003 0 0 1-2.92 4.16m0-4.16a6.003 6.003 0 0 1-4.16-2.92m0 0V2.73a6.003 6.003 0 0 1 4.16 2.92m0 0a6.003 6.003 0 0 1 2.92 4.16m-12.472-8.98a6 6 0 0 1 5.84 7.38M8.38 12.08a6.003 6.003 0 0 1-2.92-4.16M12 2.73V12A6.003 6.003 0 0 1 8.38 6.22z" />
-        <path strokeLinecap="round" strokeLinejoin="round" d="M12 12L12 21.75M12 21.75L10.5 19.5M12 21.75L13.5 19.5" /> {/* Rocket Flame */}
-        <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 17.25L7.5 19.5L6.75 17.25" /> {/* Side Flames */}
-        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25L16.5 19.5L17.25 17.25" />
-    </svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.82m5.84-2.56v4.82a6 6 0 0 1-1.89-.88M16.532 8.732a6.003 6.003 0 0 1-7.381 5.84m7.381-5.84a6.003 6.003 0 0 0-4.16-2.92m4.16 2.92a6.003 6.003 0 0 1-2.92 4.16m0-4.16a6.003 6.003 0 0 1-4.16-2.92m0 0V2.73a6.003 6.003 0 0 1 4.16 2.92m0 0a6.003 6.003 0 0 1 2.92 4.16m-12.472-8.98a6 6 0 0 1 5.84 7.38M8.38 12.08a6.003 6.003 0 0 1-2.92-4.16M12 2.73V12A6.003 6.003 0 0 1 8.38 6.22z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 12L12 21.75M12 21.75L10.5 19.5M12 21.75L13.5 19.5"
+    />{' '}
+    {/* Rocket Flame */}
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 17.25L7.5 19.5L6.75 17.25" />{' '}
+    {/* Side Flames */}
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25L16.5 19.5L17.25 17.25" />
+  </svg>
 );
 
 export const DocumentChartBarIcon: React.FC<IconProps> = ({ className, ...props }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${className || ''}`} {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125V5.25A2.25 2.25 0 0 0 11.25 3H6.75A2.25 2.25 0 0 0 4.5 5.25v13.5A2.25 2.25 0 0 0 6.75 21h10.5A2.25 2.25 0 0 0 19.5 18.75V16.5M9 14.25h6M9 11.25h3M12.75 17.25h-.008v.008h.008v-.008Z" /> {/* Added a small dot for "chart" feel */}
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6H12v1.5h3.75V6Z" /> {/* Bar chart like elements */}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={`w-6 h-6 ${className || ''}`}
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125V5.25A2.25 2.25 0 0 0 11.25 3H6.75A2.25 2.25 0 0 0 4.5 5.25v13.5A2.25 2.25 0 0 0 6.75 21h10.5A2.25 2.25 0 0 0 19.5 18.75V16.5M9 14.25h6M9 11.25h3M12.75 17.25h-.008v.008h.008v-.008Z"
+    />{' '}
+    {/* Added a small dot for "chart" feel */}
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6H12v1.5h3.75V6Z" />{' '}
+    {/* Bar chart like elements */}
     <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9H12v1.5h3.75V9Z" />
   </svg>
 );

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -7,19 +7,25 @@ const THEME_STORAGE_KEY = 'ideaforge-ascension-theme';
 // Helper to convert hex to RGB components string, e.g., "255, 191, 0"
 // This is needed for rgba() colors where Tailwind's opacity modifiers might not work with CSS vars directly.
 function getRGBComponents(hexColor: string): string {
-    let color = hexColor.startsWith('#') ? hexColor.substring(1) : hexColor;
-    if (color.length === 3) {
-        color = color.split('').map(char => char + char).join('');
-    }
-    const r = parseInt(color.substring(0, 2), 16);
-    const g = parseInt(color.substring(2, 4), 16);
-    const b = parseInt(color.substring(4, 6), 16);
-    return `${r}, ${g}, ${b}`;
+  let color = hexColor.startsWith('#') ? hexColor.substring(1) : hexColor;
+  if (color.length === 3) {
+    color = color
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  const r = parseInt(color.substring(0, 2), 16);
+  const g = parseInt(color.substring(2, 4), 16);
+  const b = parseInt(color.substring(4, 6), 16);
+  return `${r}, ${g}, ${b}`;
 }
 
 export const useTheme = () => {
   const [themeName, setThemeName] = useState<ThemeName>(() => {
-    const storedTheme = typeof window !== 'undefined' ? localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null : null;
+    const storedTheme =
+      typeof window !== 'undefined'
+        ? (localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null)
+        : null;
     return storedTheme && themes[storedTheme] ? storedTheme : 'dark'; // Default to dark theme
   });
 
@@ -32,7 +38,7 @@ export const useTheme = () => {
     }
 
     const root = document.documentElement;
-    
+
     // Set main theme class
     root.classList.remove('theme-light', 'theme-dark', 'theme-cosmic');
     root.classList.add(`theme-${newThemeName}`);
@@ -42,41 +48,52 @@ export const useTheme = () => {
     Object.entries(selectedTheme.colors).forEach(([key, value]) => {
       // Convert key from camelCase to kebab-case for CSS custom property
       const cssVarName = `--color-${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
-      if(value) root.style.setProperty(cssVarName, value);
+      if (value) root.style.setProperty(cssVarName, value);
     });
-    
+
     // Set RGB versions for specific variables used with alpha transparency
     // This is useful for components like .glassmorphic
     if (selectedTheme.colors.bgPrimary) {
-        root.style.setProperty('--rgb-bg-primary', getRGBComponents(selectedTheme.colors.bgPrimary));
+      root.style.setProperty('--rgb-bg-primary', getRGBComponents(selectedTheme.colors.bgPrimary));
     }
     if (selectedTheme.colors.bgAccent) {
-        root.style.setProperty('--rgb-bg-accent', getRGBComponents(selectedTheme.colors.bgAccent));
+      root.style.setProperty('--rgb-bg-accent', getRGBComponents(selectedTheme.colors.bgAccent));
     }
     if (selectedTheme.colors.textPrimary) {
-        root.style.setProperty('--rgb-text-primary', getRGBComponents(selectedTheme.colors.textPrimary));
+      root.style.setProperty(
+        '--rgb-text-primary',
+        getRGBComponents(selectedTheme.colors.textPrimary)
+      );
     }
     if (selectedTheme.colors.borderAccent) {
-        root.style.setProperty('--rgb-border-accent', getRGBComponents(selectedTheme.colors.borderAccent));
+      root.style.setProperty(
+        '--rgb-border-accent',
+        getRGBComponents(selectedTheme.colors.borderAccent)
+      );
     }
     if (selectedTheme.colors.accentPrimary) {
-        root.style.setProperty('--rgb-accent-primary', getRGBComponents(selectedTheme.colors.accentPrimary));
+      root.style.setProperty(
+        '--rgb-accent-primary',
+        getRGBComponents(selectedTheme.colors.accentPrimary)
+      );
     }
     if (selectedTheme.colors.accentSecondary) {
-        root.style.setProperty('--rgb-accent-secondary', getRGBComponents(selectedTheme.colors.accentSecondary));
+      root.style.setProperty(
+        '--rgb-accent-secondary',
+        getRGBComponents(selectedTheme.colors.accentSecondary)
+      );
     }
-
 
     // Persist theme choice
     localStorage.setItem(THEME_STORAGE_KEY, newThemeName);
     setThemeName(newThemeName);
   }, []);
-  
+
   useEffect(() => {
     // Apply initial theme on mount
     applyTheme(themeName);
   }, [applyTheme, themeName]); // applyTheme dependency can be problematic if it changes too often.
-                              // For this setup, it should be stable.
+  // For this setup, it should be stable.
 
   return {
     currentThemeName: themeName,

--- a/index.html
+++ b/index.html
@@ -1,57 +1,59 @@
-
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>IdeaForge: Your Cosmic Forge</title>  
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            'cosmic-dark': '#0b0c26',
-            'cosmic-purple-dark': '#1d3557',
-            'cosmic-purple-mid': '#3a0ca3',
-            'cosmic-purple-light': '#7209b7',
-            'cosmic-pink': '#f72585',
-            'cosmic-orange': '#fca311',
-            'cosmic-text-primary': '#ffffff',
-            'cosmic-text-secondary': '#adb5bd',
-          },
-          fontFamily: {
-            sans: ['Montserrat', 'sans-serif'],
-            body: ['Poppins', 'sans-serif'],
-          },
-          boxShadow: {
-             'glow-lg': '0 0 15px theme(colors.cosmic-pink), 0 0 30px theme(colors.cosmic-pink)',
-             'glow-xl': '0 0 25px theme(colors.cosmic-pink), 0 0 50px theme(colors.cosmic-pink)',
-          },
-          dropShadow: {
-            'glow-pink': '0 0 15px #f72585',
-          },
-          keyframes: {
-            'background-pan': {
-              '0%': { 'background-position': '0% 50%' },
-              '50%': { 'background-position': '100% 50%' },
-              '100%': { 'background-position': '0% 50%' },
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IdeaForge: Your Cosmic Forge</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              'cosmic-dark': '#0b0c26',
+              'cosmic-purple-dark': '#1d3557',
+              'cosmic-purple-mid': '#3a0ca3',
+              'cosmic-purple-light': '#7209b7',
+              'cosmic-pink': '#f72585',
+              'cosmic-orange': '#fca311',
+              'cosmic-text-primary': '#ffffff',
+              'cosmic-text-secondary': '#adb5bd',
+            },
+            fontFamily: {
+              sans: ['Montserrat', 'sans-serif'],
+              body: ['Poppins', 'sans-serif'],
+            },
+            boxShadow: {
+              'glow-lg': '0 0 15px theme(colors.cosmic-pink), 0 0 30px theme(colors.cosmic-pink)',
+              'glow-xl': '0 0 25px theme(colors.cosmic-pink), 0 0 50px theme(colors.cosmic-pink)',
+            },
+            dropShadow: {
+              'glow-pink': '0 0 15px #f72585',
+            },
+            keyframes: {
+              'background-pan': {
+                '0%': { 'background-position': '0% 50%' },
+                '50%': { 'background-position': '100% 50%' },
+                '100%': { 'background-position': '0% 50%' },
+              },
+            },
+            animation: {
+              'background-pan': 'background-pan 30s ease-in-out infinite',
             },
           },
-          animation: {
-            'background-pan': 'background-pan 30s ease-in-out infinite',
-          },
-        }
-      }
-    }
-  </script>
-<link rel="stylesheet" href="/index.css">
-</head>
-<body>
-  <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
-</body>
+        },
+      };
+    </script>
+    <link rel="stylesheet" href="/index.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/index.tsx"></script>
+  </body>
 </html>

--- a/index.tsx
+++ b/index.tsx
@@ -6,7 +6,7 @@ import ErrorBoundary from './components/ErrorBoundary'; // Import the ErrorBound
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  throw new Error("Could not find root element to mount to");
+  throw new Error('Could not find root element to mount to');
 }
 
 const root = ReactDOM.createRoot(rootElement);

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,13 @@
 // jest.config.cjs
 module.exports = {
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/src', '<rootDir>/components', '<rootDir>/services', '<rootDir>/hooks', '<rootDir>/utils'],
+  roots: [
+    '<rootDir>/src',
+    '<rootDir>/components',
+    '<rootDir>/services',
+    '<rootDir>/hooks',
+    '<rootDir>/utils',
+  ],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -59,7 +59,7 @@ if (typeof (window as any).JSZip === 'undefined') {
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn().mockImplementation(query => ({
+  value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,

--- a/motion/variants.ts
+++ b/motion/variants.ts
@@ -3,16 +3,16 @@ import { Variants } from 'framer-motion';
 
 export const fadeIn: Variants = {
   hidden: { opacity: 0, y: 10 },
-  visible: { 
-    opacity: 1, 
+  visible: {
+    opacity: 1,
     y: 0,
-    transition: { duration: 0.5, ease: "easeOut" }
+    transition: { duration: 0.5, ease: 'easeOut' },
   },
   exit: {
     opacity: 0,
     y: -10,
-    transition: { duration: 0.3, ease: "easeIn" }
-  }
+    transition: { duration: 0.3, ease: 'easeIn' },
+  },
 };
 
 export const staggerContainer: Variants = {
@@ -28,29 +28,29 @@ export const staggerContainer: Variants = {
 
 export const staggerItem: Variants = {
   hidden: { opacity: 0, y: 20 },
-  visible: { 
-    opacity: 1, 
+  visible: {
+    opacity: 1,
     y: 0,
-    transition: { type: "spring", stiffness: 100, damping: 12 }
+    transition: { type: 'spring', stiffness: 100, damping: 12 },
   },
 };
 
 export const slideInFromLeft: Variants = {
   hidden: { x: '-100vw', opacity: 0 },
-  visible: { 
-    x: 0, 
-    opacity: 1, 
-    transition: { type: 'spring', stiffness: 50, damping: 20 } 
+  visible: {
+    x: 0,
+    opacity: 1,
+    transition: { type: 'spring', stiffness: 50, damping: 20 },
   },
   exit: { x: '-100vw', opacity: 0, transition: { ease: 'easeInOut', duration: 0.3 } },
 };
 
 export const slideInFromRight: Variants = {
   hidden: { x: '100vw', opacity: 0 },
-  visible: { 
-    x: 0, 
-    opacity: 1, 
-    transition: { type: 'spring', stiffness: 50, damping: 20 } 
+  visible: {
+    x: 0,
+    opacity: 1,
+    transition: { type: 'spring', stiffness: 50, damping: 20 },
   },
   exit: { x: '100vw', opacity: 0, transition: { ease: 'easeInOut', duration: 0.3 } },
 };
@@ -64,7 +64,7 @@ export const slideDown: Variants = {
       type: 'spring',
       stiffness: 40,
       damping: 15,
-      duration: 0.7
+      duration: 0.7,
     },
   },
   exit: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ideaforge-ascension",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.7.0",
         "framer-motion": "^12.19.2",
@@ -22,7 +23,7 @@
         "@jest/globals": "^30.0.3",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
-        "@types/jest": "^29.5.12",
+        "@types/jest": "^29.5.14",
         "@types/jszip": "^3.4.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -44,7 +45,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.3",
-        "ts-jest": "^29.1.2",
+        "ts-jest": "^29.4.0",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.35.0",
         "vite": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@jest/globals": "^30.0.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@types/jest": "^29.5.12",
+    "@types/jest": "^29.5.14",
     "@types/jszip": "^3.4.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -50,7 +50,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.3",
-    "ts-jest": "^29.1.2",
+    "ts-jest": "^29.4.0",
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.35.0",
     "vite": "^7.0.0"

--- a/rendering/CosmicCanvas.tsx
+++ b/rendering/CosmicCanvas.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { useTheme } from '../hooks/useTheme';
 
-const CosmicCanvas: React.FC<{className?: string}> = ({ className }) => {
+const CosmicCanvas: React.FC<{ className?: string }> = ({ className }) => {
   const { currentThemeProperties } = useTheme();
 
   const starColorPrimary = currentThemeProperties.colors.textPrimary;
@@ -11,51 +11,55 @@ const CosmicCanvas: React.FC<{className?: string}> = ({ className }) => {
   const bgColorPrimary = currentThemeProperties.colors.bgPrimary;
 
   return (
-    <div 
+    <div
       className={`fixed inset-0 -z-10 overflow-hidden ${className || ''}`}
       style={{ backgroundColor: bgColorPrimary }}
       aria-hidden="true"
     >
-      <div 
+      <div
         className="absolute inset-0 bg-cover bg-no-repeat bg-center animate-nebula-drift"
-        style={{ 
+        style={{
           backgroundImage: `url('assets/images/nebula-bg.jpg')`,
-          willChange: 'transform, opacity'
+          willChange: 'transform, opacity',
         }}
-       />
-      
+      />
+
       {[...Array(70)].map((_, i) => (
-          <div 
-            key={`star-p-${i}`}
-            className="absolute animate-twinkle"
-            style={{
-                width: `${Math.random() * 2 + 1}px`, height: `${Math.random() * 2 + 1}px`,
-                background: Math.random() > 0.7 ? starColorAccent : starColorPrimary,
-                borderRadius: '50%',
-                top: `${Math.random() * 100}%`, left: `${Math.random() * 100}%`,
-                opacity: Math.random() * 0.7 + 0.3,
-                boxShadow: `0 0 ${Math.random() * 4 + 2}px ${Math.random() > 0.5 ? starColorAccent : starColorPrimary}`,
-                animationDelay: `${Math.random() * -10}s`,
-                animationDuration: `${Math.random() * 5 + 4}s`,
-                willChange: 'opacity, transform'
-            }}
-          />
+        <div
+          key={`star-p-${i}`}
+          className="absolute animate-twinkle"
+          style={{
+            width: `${Math.random() * 2 + 1}px`,
+            height: `${Math.random() * 2 + 1}px`,
+            background: Math.random() > 0.7 ? starColorAccent : starColorPrimary,
+            borderRadius: '50%',
+            top: `${Math.random() * 100}%`,
+            left: `${Math.random() * 100}%`,
+            opacity: Math.random() * 0.7 + 0.3,
+            boxShadow: `0 0 ${Math.random() * 4 + 2}px ${Math.random() > 0.5 ? starColorAccent : starColorPrimary}`,
+            animationDelay: `${Math.random() * -10}s`,
+            animationDuration: `${Math.random() * 5 + 4}s`,
+            willChange: 'opacity, transform',
+          }}
+        />
       ))}
       {[...Array(50)].map((_, i) => (
-          <div 
-            key={`star-s-${i}`}
-            className="absolute animate-twinkle"
-            style={{
-                width: `${Math.random() * 1.5 + 0.5}px`, height: `${Math.random() * 1.5 + 0.5}px`,
-                background: starColorSecondary,
-                borderRadius: '50%',
-                top: `${Math.random() * 100}%`, left: `${Math.random() * 100}%`,
-                opacity: Math.random() * 0.4 + 0.2,
-                animationDelay: `${Math.random() * -12}s`,
-                animationDuration: `${Math.random() * 7 + 5}s`,
-                willChange: 'opacity, transform'
-            }}
-          />
+        <div
+          key={`star-s-${i}`}
+          className="absolute animate-twinkle"
+          style={{
+            width: `${Math.random() * 1.5 + 0.5}px`,
+            height: `${Math.random() * 1.5 + 0.5}px`,
+            background: starColorSecondary,
+            borderRadius: '50%',
+            top: `${Math.random() * 100}%`,
+            left: `${Math.random() * 100}%`,
+            opacity: Math.random() * 0.4 + 0.2,
+            animationDelay: `${Math.random() * -12}s`,
+            animationDuration: `${Math.random() * 7 + 5}s`,
+            willChange: 'opacity, transform',
+          }}
+        />
       ))}
     </div>
   );

--- a/services/fileService.test.ts
+++ b/services/fileService.test.ts
@@ -1,5 +1,3 @@
-
-
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import {
   generateMarkdownContent,
@@ -23,23 +21,29 @@ Object.defineProperty(window, 'JSZip', {
     file: mockZipFile,
     folder: mockZipFolder,
     generateAsync: mockZipGenerateAsync,
-    loadAsync: mockZipLoadAsync, 
+    loadAsync: mockZipLoadAsync,
   })),
-  writable: true, 
+  writable: true,
 });
-
 
 // Mock Blob and URL.createObjectURL/revokeObjectURL
 // @ts-ignore
 globalThis.Blob = jest.fn((content?: BlobPart[], options?: BlobPropertyBag) => ({
   content,
   options,
-  size: content && Array.isArray(content) && typeof content[0] === 'string' ? (content[0] as string).length : 0,
+  size:
+    content && Array.isArray(content) && typeof content[0] === 'string'
+      ? (content[0] as string).length
+      : 0,
   type: options?.type || '',
   arrayBuffer: jest.fn<() => Promise<ArrayBuffer>>().mockResolvedValue(new ArrayBuffer(0)),
   slice: jest.fn(),
   stream: jest.fn(),
-  text: jest.fn<() => Promise<string>>().mockResolvedValue(content && Array.isArray(content) && typeof content[0] === 'string' ? content[0] : ''),
+  text: jest
+    .fn<() => Promise<string>>()
+    .mockResolvedValue(
+      content && Array.isArray(content) && typeof content[0] === 'string' ? content[0] : ''
+    ),
 })) as unknown as typeof Blob; // Cast to actual Blob type for tsc
 URL.createObjectURL = jest.fn(() => 'mock-url');
 URL.revokeObjectURL = jest.fn();
@@ -61,7 +65,6 @@ Object.defineProperty(document, 'createElement', {
 Object.defineProperty(document.body, 'appendChild', { value: mockAppendChild, writable: true });
 Object.defineProperty(document.body, 'removeChild', { value: mockRemoveChild, writable: true });
 
-
 const sampleIdea: Idea = {
   id: 'idea1',
   title: 'My Awesome Idea!',
@@ -71,8 +74,22 @@ const sampleIdea: Idea = {
   targetAudience: 'Everyone',
   inspirationNotes: 'Cookies are great.',
   attachments: [
-    { id: 'att1', name: 'logo with space.png', type: 'image', mimeType: 'image/png', content: 'base64imagestring', size: 1024 },
-    { id: 'att2', name: 'notes <unsafe>.txt', type: 'text', mimeType: 'text/plain', content: 'Some text notes.', size: 512 },
+    {
+      id: 'att1',
+      name: 'logo with space.png',
+      type: 'image',
+      mimeType: 'image/png',
+      content: 'base64imagestring',
+      size: 1024,
+    },
+    {
+      id: 'att2',
+      name: 'notes <unsafe>.txt',
+      type: 'text',
+      mimeType: 'text/plain',
+      content: 'Some text notes.',
+      size: 512,
+    },
   ],
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
@@ -82,7 +99,7 @@ const sampleProject: Project = {
   id: 'proj1',
   name: 'Cookie Project / Division',
   ideas: [sampleIdea],
-  attachments: [], 
+  attachments: [],
   createdAt: new Date().toISOString(),
   isFavorite: false,
 };
@@ -91,13 +108,15 @@ const sampleProject: Project = {
 const mockFileReaderInstance = {
   onload: null as ((event: ProgressEvent<FileReader>) => void) | null,
   onerror: null as ((event: ProgressEvent<FileReader>) => void) | null,
-  readAsText: jest.fn(function(this: FileReader, blob: Blob) { // Takes Blob/File
+  readAsText: jest.fn(function (this: FileReader, blob: Blob) {
+    // Takes Blob/File
     // @ts-ignore
     this.result = (blob as any)._customContent || 'hello world'; // Simulate reading content
     // @ts-ignore
     if (this.onload) this.onload({ target: this } as ProgressEvent<FileReader>);
   }),
-  readAsDataURL: jest.fn(function(this: FileReader, blob: Blob) { // Takes Blob/File
+  readAsDataURL: jest.fn(function (this: FileReader, blob: Blob) {
+    // Takes Blob/File
     // @ts-ignore
     this.result = (blob as any)._customBase64Content || 'data:image/png;base64,ZGF0YQ==';
     // @ts-ignore
@@ -108,8 +127,9 @@ const mockFileReaderInstance = {
 };
 
 // Mock the global FileReader constructor to return our mock instance
-(globalThis as any).FileReader = jest.fn(() => mockFileReaderInstance) as unknown as typeof FileReader;
-
+(globalThis as any).FileReader = jest.fn(
+  () => mockFileReaderInstance
+) as unknown as typeof FileReader;
 
 describe('fileService', () => {
   beforeEach(() => {
@@ -129,11 +149,21 @@ describe('fileService', () => {
       expect(markdown).toContain(`# ${sampleIdea.title}`);
       expect(markdown).toContain(`## Problem Solved:\n${sampleIdea.problemSolved}`);
       expect(markdown).toContain(`![logo with space.png](./attachments/logo_with_space.png)`);
-      expect(markdown).toContain(`- notes <unsafe>.txt (type: text, size: 0 KB) - See ./attachments/notes_unsafe_.txt`);
+      expect(markdown).toContain(
+        `- notes <unsafe>.txt (type: text, size: 0 KB) - See ./attachments/notes_unsafe_.txt`
+      );
     });
 
-     test('should handle missing fields gracefully', () => {
-      const minimalIdea: Idea = { ...sampleIdea, problemSolved: '', coreSolution: '', keyFeatures: '', targetAudience:'', inspirationNotes: '', attachments: [] };
+    test('should handle missing fields gracefully', () => {
+      const minimalIdea: Idea = {
+        ...sampleIdea,
+        problemSolved: '',
+        coreSolution: '',
+        keyFeatures: '',
+        targetAudience: '',
+        inspirationNotes: '',
+        attachments: [],
+      };
       const markdown = generateMarkdownContent(minimalIdea);
       expect(markdown).toContain(`## Problem Solved:\nN/A`);
       expect(markdown).not.toContain(`## Attachments:`);
@@ -142,13 +172,15 @@ describe('fileService', () => {
 
   describe('sanitizeFilename', () => {
     test('should replace invalid characters with underscores', () => {
-      expect(sanitizeFilename('file/name*with?chars"<>|#%&{}.txt')).toBe('file_name_with_chars_.txt');
+      expect(sanitizeFilename('file/name*with?chars"<>|#%&{}.txt')).toBe(
+        'file_name_with_chars_.txt'
+      );
     });
     test('should replace multiple spaces with a single underscore', () => {
       expect(sanitizeFilename('file  with   spaces.txt')).toBe('file_with_spaces.txt');
     });
     test('should truncate long filenames', () => {
-      const longName = `${'a'.repeat(150)  }.txt`;
+      const longName = `${'a'.repeat(150)}.txt`;
       expect(sanitizeFilename(longName).length).toBe(100 + 4); // 100 for name + .txt
     });
   });
@@ -163,11 +195,13 @@ describe('fileService', () => {
       const ideaNoAttachments = { ...sampleIdea, attachments: [] };
       await exportIdea(ideaNoAttachments);
 
-      expect(globalThis.Blob).toHaveBeenCalledWith([expect.any(String)], { type: 'text/markdown;charset=utf-8' }); 
+      expect(globalThis.Blob).toHaveBeenCalledWith([expect.any(String)], {
+        type: 'text/markdown;charset=utf-8',
+      });
       expect(mockLinkClick).toHaveBeenCalled();
       expect(URL.createObjectURL).toHaveBeenCalled();
       expect(URL.revokeObjectURL).toHaveBeenCalled();
-      
+
       // @ts-ignore
       window.JSZip = originalJSZip; // Restore JSZip
     });
@@ -212,7 +246,9 @@ describe('fileService', () => {
       const originalJSZip = window.JSZip;
       // @ts-ignore
       window.JSZip = undefined;
-      await expect(exportProjectAsZip(sampleProject)).rejects.toThrow('JSZip library is not available.');
+      await expect(exportProjectAsZip(sampleProject)).rejects.toThrow(
+        'JSZip library is not available.'
+      );
       // @ts-ignore
       window.JSZip = originalJSZip;
     });
@@ -222,26 +258,28 @@ describe('fileService', () => {
     test('should read file as text successfully', async () => {
       const file = new File(['hello world'], 'hello.txt', { type: 'text/plain' });
       // @ts-ignore Add custom property for mock content
-      (file as any)._customContent = 'hello world'; 
-      
+      (file as any)._customContent = 'hello world';
+
       const content = await readFileAsText(file);
       expect(content).toBe('hello world');
       expect(mockFileReaderInstance.readAsText).toHaveBeenCalledWith(file);
     });
 
     test('should reject on file read error (text)', async () => {
-        const file = new File([''], 'error.txt', { type: 'text/plain' });
-        const mockError = new DOMException("Test read error");
-        
-        // Configure the mock instance for error
-        mockFileReaderInstance.readAsText.mockImplementationOnce(function(this: FileReader) {
-            // @ts-ignore
-            this.error = mockError;
-            // @ts-ignore
-            if (this.onerror) this.onerror({ target: this } as ProgressEvent<FileReader>);
-        });
+      const file = new File([''], 'error.txt', { type: 'text/plain' });
+      const mockError = new DOMException('Test read error');
 
-        await expect(readFileAsText(file)).rejects.toThrow('Failed to read file "error.txt" as text: Test read error');
+      // Configure the mock instance for error
+      mockFileReaderInstance.readAsText.mockImplementationOnce(function (this: FileReader) {
+        // @ts-ignore
+        this.error = mockError;
+        // @ts-ignore
+        if (this.onerror) this.onerror({ target: this } as ProgressEvent<FileReader>);
+      });
+
+      await expect(readFileAsText(file)).rejects.toThrow(
+        'Failed to read file "error.txt" as text: Test read error'
+      );
     });
   });
 

--- a/services/fileService.ts
+++ b/services/fileService.ts
@@ -1,4 +1,3 @@
-
 import JSZip from 'jszip';
 import { Idea, Project } from '../types';
 
@@ -13,8 +12,10 @@ export const base64ToBlob = (base64: string, type = 'application/octet-stream'):
     const byteArray = new Uint8Array(byteNumbers);
     return new Blob([byteArray], { type });
   } catch (error) {
-    console.error("Error converting Base64 to Blob:", error);
-    throw new Error(`Failed to convert Base64 string to Blob: ${error instanceof Error ? error.message : String(error)}`);
+    console.error('Error converting Base64 to Blob:', error);
+    throw new Error(
+      `Failed to convert Base64 string to Blob: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 };
 
@@ -22,16 +23,16 @@ export const generateMarkdownContent = (idea: Idea): string => {
   let content = `# ${idea.title}\n\n`;
   content += `## Problem Solved:\n${idea.problemSolved || 'N/A'}\n\n`;
   content += `## Core Solution/Concept:\n${idea.coreSolution || 'N/A'}\n\n`;
-  content += `## Key Features:\n${idea.keyFeatures || 'N/A'}\n\n`; 
+  content += `## Key Features:\n${idea.keyFeatures || 'N/A'}\n\n`;
   content += `## Target Audience:\n${idea.targetAudience || 'N/A'}\n\n`;
   content += `## Inspiration/Notes:\n${idea.inspirationNotes || 'N/A'}\n\n`;
 
   if (idea.attachments.length > 0) {
     content += `## Attachments:\n`;
-    idea.attachments.forEach(att => {
+    idea.attachments.forEach((att) => {
       if (att.type === 'image') {
         // Relative path for zip structure
-        content += `![${att.name}](./attachments/${sanitizeFilename(att.name)})\n`; 
+        content += `![${att.name}](./attachments/${sanitizeFilename(att.name)})\n`;
       } else {
         content += `- ${att.name} (type: ${att.type}, size: ${Math.round(att.size / 1024)} KB) - See ./attachments/${sanitizeFilename(att.name)}\n`;
       }
@@ -40,10 +41,12 @@ export const generateMarkdownContent = (idea: Idea): string => {
   return content;
 };
 
-export const sanitizeFilename = (name: string): string => 
+export const sanitizeFilename = (name: string): string =>
   // Replace problematic characters and multiple spaces with a single underscore
-   name.replace(/[\\/:*?"<>|#%&{}]/g, '_').replace(/\s+/g, '_').substring(0, 100)
-;
+  name
+    .replace(/[\\/:*?"<>|#%&{}]/g, '_')
+    .replace(/\s+/g, '_')
+    .substring(0, 100);
 
 const formatDateForFilename = (date: Date): string => {
   const YYYY = date.getFullYear();
@@ -65,24 +68,30 @@ export const exportIdea = async (idea: Idea): Promise<void> => {
     if (idea.attachments.length > 0) {
       const zip = new JSZip();
       zip.file(markdownFilename, markdownContent);
-      const attachmentsFolder = zip.folder('attachments'); 
-      if (!attachmentsFolder) throw new Error("Could not create attachments folder in ZIP.");
-      
+      const attachmentsFolder = zip.folder('attachments');
+      if (!attachmentsFolder) throw new Error('Could not create attachments folder in ZIP.');
+
       for (const att of idea.attachments) {
-          const blob = base64ToBlob(att.content, att.mimeType);
-          attachmentsFolder.file(sanitizeFilename(att.name), blob);
+        const blob = base64ToBlob(att.content, att.mimeType);
+        attachmentsFolder.file(sanitizeFilename(att.name), blob);
       }
-      
+
       const zipBlob = await zip.generateAsync({ type: 'blob' });
-      downloadFile(`${baseFilename}_${timestamp}.zip`, URL.createObjectURL(zipBlob), 'application/zip');
+      downloadFile(
+        `${baseFilename}_${timestamp}.zip`,
+        URL.createObjectURL(zipBlob),
+        'application/zip'
+      );
     } else {
       // No attachments, just download Markdown
       const blob = new Blob([markdownContent], { type: 'text/markdown;charset=utf-8' });
       downloadFile(markdownFilename, URL.createObjectURL(blob), 'text/markdown;charset=utf-8');
     }
   } catch (error) {
-    console.error("Error exporting idea:", error);
-    throw new Error(`Failed to export idea "${idea.title}": ${error instanceof Error ? error.message : String(error)}`);
+    console.error('Error exporting idea:', error);
+    throw new Error(
+      `Failed to export idea "${idea.title}": ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 };
 
@@ -93,17 +102,19 @@ export const exportProjectAsZip = async (project: Project): Promise<void> => {
     const projectFolder = zip.folder(projectBaseFilename);
 
     if (!projectFolder) {
-      throw new Error("Could not create project folder in ZIP.");
+      throw new Error('Could not create project folder in ZIP.');
     }
 
     for (const idea of project.ideas) {
       const ideaBaseFilename = sanitizeFilename(idea.title) || 'Untitled_Idea';
       const ideaMarkdownFilename = `README.md`; // Store markdown as README in idea's folder
       const markdownContent = generateMarkdownContent(idea);
-      
-      const ideaSubFolder = projectFolder.folder(ideaBaseFilename); 
+
+      const ideaSubFolder = projectFolder.folder(ideaBaseFilename);
       if (!ideaSubFolder) {
-        console.warn(`Could not create subfolder for idea "${idea.title}" in project ZIP. Skipping this idea's folder structure.`);
+        console.warn(
+          `Could not create subfolder for idea "${idea.title}" in project ZIP. Skipping this idea's folder structure.`
+        );
         projectFolder.file(`${ideaBaseFilename}.md`, markdownContent); // Fallback to flat MD
         continue;
       }
@@ -118,20 +129,27 @@ export const exportProjectAsZip = async (project: Project): Promise<void> => {
             attachmentsFolder.file(sanitizeFilename(att.name), blob);
           }
         } else {
-            console.warn(`Could not create attachments folder for idea "${idea.title}" in project ZIP.`);
+          console.warn(
+            `Could not create attachments folder for idea "${idea.title}" in project ZIP.`
+          );
         }
       }
     }
 
     const zipBlob = await zip.generateAsync({ type: 'blob' });
     const timestamp = formatDateForFilename(new Date());
-    downloadFile(`${projectBaseFilename}_${timestamp}.zip`, URL.createObjectURL(zipBlob), 'application/zip');
+    downloadFile(
+      `${projectBaseFilename}_${timestamp}.zip`,
+      URL.createObjectURL(zipBlob),
+      'application/zip'
+    );
   } catch (error) {
-    console.error("Error exporting project:", error);
-    throw new Error(`Failed to export project "${project.name}": ${error instanceof Error ? error.message : String(error)}`);
+    console.error('Error exporting project:', error);
+    throw new Error(
+      `Failed to export project "${project.name}": ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 };
-
 
 const downloadFile = (filename: string, href: string, mimeType?: string): void => {
   try {
@@ -144,28 +162,38 @@ const downloadFile = (filename: string, href: string, mimeType?: string): void =
     document.body.removeChild(link);
     URL.revokeObjectURL(href); // Clean up
   } catch (error) {
-    console.error("Error in downloadFile utility:", error);
+    console.error('Error in downloadFile utility:', error);
     // This error won't be easily caught by calling functions unless re-thrown,
     // but it's important for debugging.
   }
 };
 
-export const readFileAsText = (file: File): Promise<string> => new Promise((resolve, reject) => {
+export const readFileAsText = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);
     reader.onerror = (event) => {
-        console.error("Error reading file as text:", event.target?.error);
-        reject(new Error(`Failed to read file "${file.name}" as text: ${event.target?.error?.message || 'Unknown error'}`));
+      console.error('Error reading file as text:', event.target?.error);
+      reject(
+        new Error(
+          `Failed to read file "${file.name}" as text: ${event.target?.error?.message || 'Unknown error'}`
+        )
+      );
     };
     reader.readAsText(file);
   });
 
-export const readFileAsBase64 = (file: File): Promise<string> => new Promise((resolve, reject) => {
+export const readFileAsBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);
     reader.onerror = (event) => {
-        console.error("Error reading file as Base64:", event.target?.error);
-        reject(new Error(`Failed to read file "${file.name}" as Base64: ${event.target?.error?.message || 'Unknown error'}`));
+      console.error('Error reading file as Base64:', event.target?.error);
+      reject(
+        new Error(
+          `Failed to read file "${file.name}" as Base64: ${event.target?.error?.message || 'Unknown error'}`
+        )
+      );
     };
     reader.readAsDataURL(file);
   });

--- a/services/localStorageService.ts
+++ b/services/localStorageService.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
+import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
 import { Project, Idea, SampleProject, Attachment } from '../types';
 
 // Initialize Gemini AI Client
@@ -9,11 +9,11 @@ try {
   if (apiKey) {
     ai = new GoogleGenAI({ apiKey });
   } else {
-    console.warn("API_KEY environment variable not found. Gemini features will be disabled.");
+    console.warn('API_KEY environment variable not found. Gemini features will be disabled.');
   }
 } catch (error) {
-  console.error("Failed to initialize GoogleGenAI:", error);
-  ai = null; 
+  console.error('Failed to initialize GoogleGenAI:', error);
+  ai = null;
 }
 
 export const isAiEnabled = (): boolean => !!ai;
@@ -23,10 +23,13 @@ const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 500;
 
 async function delay(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function withRetries<T>(asyncFn: () => Promise<T>, operationName: string = "Operation"): Promise<T> {
+export async function withRetries<T>(
+  asyncFn: () => Promise<T>,
+  operationName: string = 'Operation'
+): Promise<T> {
   let attempts = 0;
   let currentDelay = INITIAL_DELAY_MS;
 
@@ -35,9 +38,13 @@ export async function withRetries<T>(asyncFn: () => Promise<T>, operationName: s
       return await asyncFn();
     } catch (error) {
       attempts++;
-      console.warn(`[${operationName}] Attempt ${attempts} failed: ${error instanceof Error ? error.message : String(error)}`);
+      console.warn(
+        `[${operationName}] Attempt ${attempts} failed: ${error instanceof Error ? error.message : String(error)}`
+      );
       if (attempts >= MAX_RETRIES) {
-        console.error(`[${operationName}] All ${MAX_RETRIES} attempts failed. Last error: ${error instanceof Error ? error.message : String(error)}`);
+        console.error(
+          `[${operationName}] All ${MAX_RETRIES} attempts failed. Last error: ${error instanceof Error ? error.message : String(error)}`
+        );
         throw error; // Re-throw the last error after all retries
       }
       await delay(currentDelay);
@@ -45,28 +52,32 @@ export async function withRetries<T>(asyncFn: () => Promise<T>, operationName: s
     }
   }
   // This line should technically be unreachable if MAX_RETRIES > 0
-  throw new Error(`[${operationName}] Failed after ${MAX_RETRIES} attempts. This should not happen.`);
+  throw new Error(
+    `[${operationName}] Failed after ${MAX_RETRIES} attempts. This should not happen.`
+  );
 }
 
 // --- AI Feature Functions (NEW IMPLEMENTATION) ---
 
-export const testAiConnection = async (): Promise<{ success: boolean; data?: string; message?: string }> => {
-  if (!ai) return { success: false, message: "AI client not initialized or API key missing." };
-  
+export const testAiConnection = async (): Promise<{
+  success: boolean;
+  data?: string;
+  message?: string;
+}> => {
+  if (!ai) return { success: false, message: 'AI client not initialized or API key missing.' };
+
   try {
-    const operation = async (): Promise<GenerateContentResponse> => 
+    const operation = async (): Promise<GenerateContentResponse> =>
       // Non-null assertion is safe here due to the check above.
-       await ai!.models.generateContent({
+      await ai!.models.generateContent({
         model: 'gemini-2.5-flash-preview-04-17',
         contents: "Say 'Hello' in a friendly tone.",
-      })
-    ;
-    
-    const response = await withRetries(operation, "TestAIConnection");
+      });
+    const response = await withRetries(operation, 'TestAIConnection');
     return { success: true, data: response.text };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error("AI Connection Test Failed:", errorMessage);
+    console.error('AI Connection Test Failed:', errorMessage);
     return { success: false, message: errorMessage };
   }
 };
@@ -79,7 +90,7 @@ export interface IdeaBoilerplate {
 }
 
 export const generateIdeaBoilerplate = async (ideaTitle: string): Promise<IdeaBoilerplate> => {
-  if (!ai) throw new Error("AI client not initialized.");
+  if (!ai) throw new Error('AI client not initialized.');
 
   const prompt = `Based on the app/product idea title "${ideaTitle}", generate a structured JSON object containing concise boilerplate content. The JSON object must have the following keys with string values: "problemSolved", "coreSolution", "keyFeatures", "targetAudience".
 
@@ -90,23 +101,24 @@ export const generateIdeaBoilerplate = async (ideaTitle: string): Promise<IdeaBo
 
 Respond with ONLY the JSON object.`;
 
-  const operation = async (): Promise<GenerateContentResponse> => await ai!.models.generateContent({
+  const operation = async (): Promise<GenerateContentResponse> =>
+    await ai!.models.generateContent({
       model: 'gemini-2.5-flash-preview-04-17',
       contents: prompt,
       config: {
-        responseMimeType: "application/json",
+        responseMimeType: 'application/json',
       },
     });
 
-  const response = await withRetries(operation, "GenerateBoilerplate");
-  
+  const response = await withRetries(operation, 'GenerateBoilerplate');
+
   let jsonStr = (response.text ?? '').trim();
   const fenceRegex = /^```(\w*)?\s*\n?(.*?)\n?\s*```$/s;
   const match = jsonStr.match(fenceRegex);
   if (match && match[2]) {
     jsonStr = match[2].trim();
   }
-  
+
   try {
     const parsedData = JSON.parse(jsonStr);
     // Basic validation to ensure the parsed object has the expected structure
@@ -117,30 +129,30 @@ Respond with ONLY the JSON object.`;
       typeof parsedData.targetAudience === 'string'
     ) {
       return parsedData;
-    } 
-      throw new Error("Parsed JSON from AI response is missing required fields.");
-    
+    }
+    throw new Error('Parsed JSON from AI response is missing required fields.');
   } catch (e) {
-    console.error("Failed to parse boilerplate JSON from AI:", e);
+    console.error('Failed to parse boilerplate JSON from AI:', e);
     throw new Error(`AI returned malformed data for boilerplate. Raw text: ${response.text ?? ''}`);
   }
 };
 
-
-export const summarizeIdea = async (idea: Omit<Idea, 'id' | 'attachments' | 'createdAt' | 'updatedAt' | 'logo'>): Promise<string> => {
-  if (!ai) throw new Error("AI client not initialized.");
+export const summarizeIdea = async (
+  idea: Omit<Idea, 'id' | 'attachments' | 'createdAt' | 'updatedAt' | 'logo'>
+): Promise<string> => {
+  if (!ai) throw new Error('AI client not initialized.');
   const contentToSummarize = `Title: ${idea.title}\nProblem: ${idea.problemSolved}\nSolution: ${idea.coreSolution}\nFeatures: ${idea.keyFeatures}\nAudience: ${idea.targetAudience}\nNotes: ${idea.inspirationNotes}`;
   const prompt = `Summarize the following idea/notes into a concise, well-structured paragraph. Focus on the core concept and its value. Raw text:\n\n${contentToSummarize}`;
 
-  const operation = async (): Promise<GenerateContentResponse> => await ai!.models.generateContent({
+  const operation = async (): Promise<GenerateContentResponse> =>
+    await ai!.models.generateContent({
       model: 'gemini-2.5-flash-preview-04-17',
       contents: prompt,
     });
 
-  const response = await withRetries(operation, "SummarizeIdea");
+  const response = await withRetries(operation, 'SummarizeIdea');
   return response.text ?? '';
 };
-
 
 const PROJECTS_KEY = 'IDEA_FORGE_LOCAL_PROJECTS';
 const FIRST_VISIT_KEY = 'IDEA_FORGE_LOCAL_FIRST_VISIT_DONE';
@@ -153,7 +165,6 @@ const HIGH_CONTRAST_MODE_KEY = 'IDEA_FORGE_HIGH_CONTRAST_MODE';
 const REDUCED_MOTION_KEY = 'IDEA_FORGE_REDUCED_MOTION';
 const LIST_DENSITY_KEY = 'IDEA_FORGE_LIST_DENSITY';
 
-
 // --- First Visit & Welcome Modal Preference ---
 export const isFirstVisit = (): boolean => localStorage.getItem(FIRST_VISIT_KEY) === null;
 
@@ -161,33 +172,34 @@ export const setFirstVisitDone = (): void => {
   localStorage.setItem(FIRST_VISIT_KEY, 'true');
 };
 
-export const getShowWelcomeOnNextLaunchPreference = (): boolean => localStorage.getItem(SHOW_WELCOME_ON_NEXT_LAUNCH_KEY) === 'true';
+export const getShowWelcomeOnNextLaunchPreference = (): boolean =>
+  localStorage.getItem(SHOW_WELCOME_ON_NEXT_LAUNCH_KEY) === 'true';
 
 export const setShowWelcomeOnNextLaunchPreference = (show: boolean): void => {
   localStorage.setItem(SHOW_WELCOME_ON_NEXT_LAUNCH_KEY, String(show));
 };
 
-
 // Helper to convert hex to RGB components string, e.g., "255, 191, 0"
 function getRGBComponents(hexColor: string): string {
-    let color = hexColor.startsWith('#') ? hexColor.substring(1) : hexColor;
-    if (color.length === 3) {
-        color = color.split('').map(char => char + char).join('');
-    }
-    if (color.length !== 6) {
-        console.warn(`Invalid hex color for RGB conversion: ${hexColor}. Falling back to black.`);
-        return '0, 0, 0';
-    }
-    const r = parseInt(color.substring(0, 2), 16);
-    const g = parseInt(color.substring(2, 4), 16);
-    const b = parseInt(color.substring(4, 6), 16);
-    return `${r}, ${g}, ${b}`;
+  let color = hexColor.startsWith('#') ? hexColor.substring(1) : hexColor;
+  if (color.length === 3) {
+    color = color
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  if (color.length !== 6) {
+    console.warn(`Invalid hex color for RGB conversion: ${hexColor}. Falling back to black.`);
+    return '0, 0, 0';
+  }
+  const r = parseInt(color.substring(0, 2), 16);
+  const g = parseInt(color.substring(2, 4), 16);
+  const b = parseInt(color.substring(4, 6), 16);
+  return `${r}, ${g}, ${b}`;
 }
 
 // --- Appearance & Accessibility Preferences ---
-export const getAccentColor = (): string => 
-   localStorage.getItem(ACCENT_COLOR_KEY) || '#FFBF00' // Default Amber
-;
+export const getAccentColor = (): string => localStorage.getItem(ACCENT_COLOR_KEY) || '#FFBF00'; // Default Amber
 export const setAccentColor = (color: string): void => {
   localStorage.setItem(ACCENT_COLOR_KEY, color);
   if (typeof window !== 'undefined' && window.document && window.document.documentElement) {
@@ -207,7 +219,8 @@ export const setFontSizeMultiplier = (multiplier: number): void => {
   }
 };
 
-export const getHighContrastMode = (): boolean => localStorage.getItem(HIGH_CONTRAST_MODE_KEY) === 'true';
+export const getHighContrastMode = (): boolean =>
+  localStorage.getItem(HIGH_CONTRAST_MODE_KEY) === 'true';
 export const setHighContrastMode = (enabled: boolean): void => {
   localStorage.setItem(HIGH_CONTRAST_MODE_KEY, String(enabled));
   if (typeof window !== 'undefined' && window.document && window.document.documentElement) {
@@ -231,7 +244,8 @@ export const setReducedMotion = (enabled: boolean): void => {
   }
 };
 
-export const getListDensity = (): 'compact' | 'spacious' => (localStorage.getItem(LIST_DENSITY_KEY) as 'compact' | 'spacious') || 'spacious';
+export const getListDensity = (): 'compact' | 'spacious' =>
+  (localStorage.getItem(LIST_DENSITY_KEY) as 'compact' | 'spacious') || 'spacious';
 export const setListDensity = (density: 'compact' | 'spacious'): void => {
   localStorage.setItem(LIST_DENSITY_KEY, density);
   if (typeof window !== 'undefined' && window.document && window.document.documentElement) {
@@ -250,61 +264,119 @@ export const applyStoredAppearanceSettings = (): void => {
 };
 
 // --- Base64 Placeholder Assets ---
-const placeholderProjectLogo = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNGRkJGMDAiLz4KICA8dGV4dCB4PSI1MCUiIHk9IjUwJSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9InNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMzIiIGZpbGw9IiMxQTFBMUEiPlA8L3RleHQ+Cjwvc3ZnPg==';
-const placeholderBlueprintLogo1 = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8Y2lyY2xlIGN4PSIzMiIgY3k9IjMyIiByPSIyOCIgZmlsbD0iIzRBOThFMkIiLz4KPC9zdmc+';
-const placeholderBlueprintLogo2 = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8cG9seWdvbiBwb2ludHM9IjMyLDQgNjAsNjAgNCw2MCIgZmlsbD0iIzUwRTNDMiIvPgo8L3N2Zz4=';
+const placeholderProjectLogo =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNGRkJGMDAiLz4KICA8dGV4dCB4PSI1MCUiIHk9IjUwJSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9InNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMzIiIGZpbGw9IiMxQTFBMUEiPlA8L3RleHQ+Cjwvc3ZnPg==';
+const placeholderBlueprintLogo1 =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8Y2lyY2xlIGN4PSIzMiIgY3k9IjMyIiByPSIyOCIgZmlsbD0iIzRBOThFMkIiLz4KPC9zdmc+';
+const placeholderBlueprintLogo2 =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0Ij4KICA8cG9seWdvbiBwb2ludHM9IjMyLDQgNjAsNjAgNCw2MCIgZmlsbD0iIzUwRTNDMiIvPgo8L3N2Zz4=';
 
-const tinyPdfBase64 = 'data:application/pdf;base64,JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5kb2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFszIDAgUiBdCi9Db3VudCAxCj4+CmVuZG9iagozIDAgb2JqCjw8Ci9UeXBlIC9QYWdlCi9QYXJlbnQgMiAwIFIKL01lZGlhQm94IFswIDAgMyAzXQo+PgplbmRvYmoKeHJlZgowIDQKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDEwIDAwMDAwIG4gCjAwMDAwMDAwNzkgMDAwMDAgbgogMDAwMDAwMDE3MyAwMDAwMCBuIAp0cmFpbGVyCjw8Ci9TaXplIDQKUm9vdCAxIDAgUgo+PgpzdGFydHhyZWYKMjEzCiUlRU9G';
+const tinyPdfBase64 =
+  'data:application/pdf;base64,JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5kb2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFszIDAgUiBdCi9Db3VudCAxCj4+CmVuZG9iagozIDAgb2JqCjw8Ci9UeXBlIC9QYWdlCi9QYXJlbnQgMiAwIFIKL01lZGlhQm94IFswIDAgMyAzXQo+PgplbmRvYmoKeHJlZgowIDQKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDEwIDAwMDAwIG4gCjAwMDAwMDAwNzkgMDAwMDAgbgogMDAwMDAwMDE3MyAwMDAwMCBuIAp0cmFpbGVyCjw8Ci9TaXplIDQKUm9vdCAxIDAgUgo+PgpzdGFydHhyZWYKMjEzCiUlRU9G';
 const tinyTxtBase64 = 'data:text/plain;base64,VGhpcyBpcyBhIHNhbXBsZSB0ZXh0IGZpbGUu'; // "This is a sample text file."
-const tinyPngBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='; // 1x1 transparent PNG
+const tinyPngBase64 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='; // 1x1 transparent PNG
 const tinySvgBase64 = placeholderBlueprintLogo1; // Reuse one of the SVG logos
-const tinyMdBase64 = 'data:text/markdown;base64,IyBTYW1wbGUgTWFya2Rvd24KRm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMu'; // "# Sample Markdown\nFor demonstration purposes."
+const tinyMdBase64 =
+  'data:text/markdown;base64,IyBTYW1wbGUgTWFya2Rvd24KRm9yIGRlbW9uc3RyYXRpb24gcHVycG9zZXMu'; // "# Sample Markdown\nFor demonstration purposes."
 const tinyJsonBase64 = 'data:application/json;base64,eyJrZXkiOiAidmFsdWUiLCAibnVtYmVyIjogNDJ9'; // {"key": "value", "number": 42}
-const tinyJpgBase64 = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AAf/Z'; // 1x1 black JPG
+const tinyJpgBase64 =
+  'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AAf/Z'; // 1x1 black JPG
 
 // --- Sample Project ---
 const sampleProjectData: SampleProject = {
-  name: "My First Demo Project ✨",
+  name: 'My First Demo Project ✨',
   logo: placeholderProjectLogo,
   attachments: [
-    { name: 'Brand_Guidelines.pdf', type: 'other', mimeType: 'application/pdf', content: tinyPdfBase64, size: 2345 },
-    { name: 'Market_Research.txt', type: 'text', mimeType: 'text/plain', content: tinyTxtBase64, size: 123 },
-    { name: 'Competitor_Analysis.png', type: 'image', mimeType: 'image/png', content: tinyPngBase64, size: 67 },
+    {
+      name: 'Brand_Guidelines.pdf',
+      type: 'other',
+      mimeType: 'application/pdf',
+      content: tinyPdfBase64,
+      size: 2345,
+    },
+    {
+      name: 'Market_Research.txt',
+      type: 'text',
+      mimeType: 'text/plain',
+      content: tinyTxtBase64,
+      size: 123,
+    },
+    {
+      name: 'Competitor_Analysis.png',
+      type: 'image',
+      mimeType: 'image/png',
+      content: tinyPngBase64,
+      size: 67,
+    },
   ],
   ideas: [
     {
-      title: "Eco-Friendly Commute App",
-      problemSolved: "High carbon emissions from daily commutes and traffic congestion in cities.",
-      coreSolution: "A mobile app that gamifies and rewards users for choosing sustainable transport options like cycling, walking, or public transport. Integrates with city transit data and bike-sharing services.",
-      keyFeatures: "- Route planning for eco-friendly options\\n- CO2 saved tracker and leaderboard\\n- Rewards system (discounts, badges)\\n- Community challenges",
-      targetAudience: "Environmentally conscious urban dwellers, students, and corporate employees participating in green initiatives.",
-      inspirationNotes: "Inspired by fitness tracking apps and the need for actionable climate solutions. Could partner with local businesses for rewards.",
+      title: 'Eco-Friendly Commute App',
+      problemSolved: 'High carbon emissions from daily commutes and traffic congestion in cities.',
+      coreSolution:
+        'A mobile app that gamifies and rewards users for choosing sustainable transport options like cycling, walking, or public transport. Integrates with city transit data and bike-sharing services.',
+      keyFeatures:
+        '- Route planning for eco-friendly options\\n- CO2 saved tracker and leaderboard\\n- Rewards system (discounts, badges)\\n- Community challenges',
+      targetAudience:
+        'Environmentally conscious urban dwellers, students, and corporate employees participating in green initiatives.',
+      inspirationNotes:
+        'Inspired by fitness tracking apps and the need for actionable climate solutions. Could partner with local businesses for rewards.',
       logo: placeholderBlueprintLogo1,
       attachments: [
-        { name: 'User_Flow_Diagram.svg', type: 'image', mimeType: 'image/svg+xml', content: tinySvgBase64, size: 800 },
-        { name: 'Feature_Spec.md', type: 'text', mimeType: 'text/markdown', content: tinyMdBase64, size: 450 },
+        {
+          name: 'User_Flow_Diagram.svg',
+          type: 'image',
+          mimeType: 'image/svg+xml',
+          content: tinySvgBase64,
+          size: 800,
+        },
+        {
+          name: 'Feature_Spec.md',
+          type: 'text',
+          mimeType: 'text/markdown',
+          content: tinyMdBase64,
+          size: 450,
+        },
       ],
     },
     {
-      title: "AI-Powered Recipe Generator",
-      problemSolved: "Users often have ingredients at home but lack inspiration or time to find suitable recipes, leading to food waste.",
-      coreSolution: "An app where users can input available ingredients, dietary restrictions, and preferred cuisine styles. The AI then generates unique recipes, cooking instructions, and nutritional information.",
-      keyFeatures: "- Ingredient-based recipe generation\\n- Customizable dietary filters (vegan, gluten-free, etc.)\\n- AI learning for personalized suggestions\\n- Pantry inventory tracking (optional)",
-      targetAudience: "Home cooks, busy individuals, people looking to reduce food waste, and those with specific dietary needs.",
-      inspirationNotes: "Leverage large language models for creative recipe generation. Focus on a simple, intuitive UI.",
+      title: 'AI-Powered Recipe Generator',
+      problemSolved:
+        'Users often have ingredients at home but lack inspiration or time to find suitable recipes, leading to food waste.',
+      coreSolution:
+        'An app where users can input available ingredients, dietary restrictions, and preferred cuisine styles. The AI then generates unique recipes, cooking instructions, and nutritional information.',
+      keyFeatures:
+        '- Ingredient-based recipe generation\\n- Customizable dietary filters (vegan, gluten-free, etc.)\\n- AI learning for personalized suggestions\\n- Pantry inventory tracking (optional)',
+      targetAudience:
+        'Home cooks, busy individuals, people looking to reduce food waste, and those with specific dietary needs.',
+      inspirationNotes:
+        'Leverage large language models for creative recipe generation. Focus on a simple, intuitive UI.',
       logo: placeholderBlueprintLogo2,
       attachments: [
-        { name: 'API_Documentation.json', type: 'text', mimeType: 'application/json', content: tinyJsonBase64, size: 150 },
-        { name: 'Moodboard_Inspiration.jpg', type: 'image', mimeType: 'image/jpeg', content: tinyJpgBase64, size: 90 },
+        {
+          name: 'API_Documentation.json',
+          type: 'text',
+          mimeType: 'application/json',
+          content: tinyJsonBase64,
+          size: 150,
+        },
+        {
+          name: 'Moodboard_Inspiration.jpg',
+          type: 'image',
+          mimeType: 'image/jpeg',
+          content: tinyJpgBase64,
+          size: 90,
+        },
       ],
-    }
+    },
   ],
 };
 
 export const importSampleProject = (): Project | null => {
   const projects = getProjects();
-  if (projects.find(p => p.name === sampleProjectData.name)) {
-    return projects.find(p => p.name === sampleProjectData.name) || null;
+  if (projects.find((p) => p.name === sampleProjectData.name)) {
+    return projects.find((p) => p.name === sampleProjectData.name) || null;
   }
 
   const now = new Date().toISOString();
@@ -313,7 +385,7 @@ export const importSampleProject = (): Project | null => {
     name: sampleProjectData.name,
     isFavorite: true,
     createdAt: now,
-    ideas: sampleProjectData.ideas.map(ideaData => ({
+    ideas: sampleProjectData.ideas.map((ideaData) => ({
       id: crypto.randomUUID(),
       title: ideaData.title,
       problemSolved: ideaData.problemSolved,
@@ -321,19 +393,21 @@ export const importSampleProject = (): Project | null => {
       keyFeatures: ideaData.keyFeatures,
       targetAudience: ideaData.targetAudience,
       inspirationNotes: ideaData.inspirationNotes,
-      attachments: (ideaData.attachments || []).map(att => ({ ...att, id: crypto.randomUUID() })),
+      attachments: (ideaData.attachments || []).map((att) => ({ ...att, id: crypto.randomUUID() })),
       logo: ideaData.logo || undefined,
       createdAt: now,
       updatedAt: now,
     })),
-    attachments: (sampleProjectData.attachments || []).map(att => ({ ...att, id: crypto.randomUUID() })),
+    attachments: (sampleProjectData.attachments || []).map((att) => ({
+      ...att,
+      id: crypto.randomUUID(),
+    })),
     logo: sampleProjectData.logo || undefined,
   };
   projects.push(newProject);
   saveProjects(projects);
   return newProject;
 };
-
 
 // --- Project CRUD ---
 export const getProjects = (): Project[] => {
@@ -357,36 +431,36 @@ export const createProject = (projectName: string): Project => {
     id: crypto.randomUUID(),
     name: projectName,
     ideas: [],
-    attachments: [], 
-    logo: undefined, 
+    attachments: [],
+    logo: undefined,
     createdAt: new Date().toISOString(),
     isFavorite: false,
   };
-  projects.unshift(newProject); 
+  projects.unshift(newProject);
   saveProjects(projects);
   return newProject;
 };
 
 export const getProjectById = (projectId: string): Project | undefined => {
   const projects = getProjects();
-  return projects.find(p => p.id === projectId);
+  return projects.find((p) => p.id === projectId);
 };
 
 export const updateProject = (updatedProject: Project): void => {
   let projects = getProjects();
-  projects = projects.map(p => p.id === updatedProject.id ? updatedProject : p);
+  projects = projects.map((p) => (p.id === updatedProject.id ? updatedProject : p));
   saveProjects(projects);
 };
 
 export const deleteProject = (projectId: string): void => {
   let projects = getProjects();
-  projects = projects.filter(p => p.id !== projectId);
+  projects = projects.filter((p) => p.id !== projectId);
   saveProjects(projects);
 };
 
 export const toggleFavoriteProject = (projectId: string): Project | undefined => {
   const projects = getProjects();
-  const projectIndex = projects.findIndex(p => p.id === projectId);
+  const projectIndex = projects.findIndex((p) => p.id === projectId);
   if (projectIndex > -1) {
     projects[projectIndex].isFavorite = !projects[projectIndex].isFavorite;
     saveProjects(projects);
@@ -399,7 +473,7 @@ export const toggleFavoriteProject = (projectId: string): Project | undefined =>
 export const addIdeaToProject = (projectId: string, idea: Idea): void => {
   const project = getProjectById(projectId);
   if (project) {
-    project.ideas.push(idea); 
+    project.ideas.push(idea);
     updateProject(project);
   }
 };
@@ -407,7 +481,7 @@ export const addIdeaToProject = (projectId: string, idea: Idea): void => {
 export const updateIdeaInProject = (projectId: string, updatedIdea: Idea): void => {
   const project = getProjectById(projectId);
   if (project) {
-    project.ideas = project.ideas.map(idea => idea.id === updatedIdea.id ? updatedIdea : idea); 
+    project.ideas = project.ideas.map((idea) => (idea.id === updatedIdea.id ? updatedIdea : idea));
     updateProject(project);
   }
 };
@@ -415,13 +489,16 @@ export const updateIdeaInProject = (projectId: string, updatedIdea: Idea): void 
 export const deleteIdeaFromProject = (projectId: string, ideaId: string): void => {
   const project = getProjectById(projectId);
   if (project) {
-    project.ideas = project.ideas.filter(idea => idea.id !== ideaId);
+    project.ideas = project.ideas.filter((idea) => idea.id !== ideaId);
     updateProject(project);
   }
 };
 
 // --- Attachment CRUD (Project Level) ---
-export const addAttachmentsToProject = (projectId: string, attachments: Attachment[]): Project | undefined => {
+export const addAttachmentsToProject = (
+  projectId: string,
+  attachments: Attachment[]
+): Project | undefined => {
   const project = getProjectById(projectId);
   if (project) {
     project.attachments = [...(project.attachments || []), ...attachments];
@@ -431,10 +508,13 @@ export const addAttachmentsToProject = (projectId: string, attachments: Attachme
   return undefined;
 };
 
-export const deleteAttachmentFromProject = (projectId: string, attachmentId: string): Project | undefined => {
+export const deleteAttachmentFromProject = (
+  projectId: string,
+  attachmentId: string
+): Project | undefined => {
   const project = getProjectById(projectId);
   if (project) {
-    project.attachments = (project.attachments || []).filter(att => att.id !== attachmentId);
+    project.attachments = (project.attachments || []).filter((att) => att.id !== attachmentId);
     updateProject(project);
     return project;
   }
@@ -447,27 +527,34 @@ export const getAllProjectsAsJson = (): string => {
   return JSON.stringify(projects, null, 2); // Pretty print for readability
 };
 
-export const importProjectsFromJson = (jsonString: string): { success: boolean, message: string, projectsImported?: number } => {
+export const importProjectsFromJson = (
+  jsonString: string
+): { success: boolean; message: string; projectsImported?: number } => {
   try {
     const importedProjects: Project[] = JSON.parse(jsonString);
     if (!Array.isArray(importedProjects)) {
-      throw new Error("Imported data is not an array of projects.");
+      throw new Error('Imported data is not an array of projects.');
     }
     const currentProjects = getProjects();
-    const projectMap = new Map(currentProjects.map(p => [p.id, p]));
+    const projectMap = new Map(currentProjects.map((p) => [p.id, p]));
     let importedCount = 0;
-    importedProjects.forEach(p => {
-        if (p.id && p.name) { // Basic validation
-            projectMap.set(p.id, p);
-            importedCount++;
-        }
+    importedProjects.forEach((p) => {
+      if (p.id && p.name) {
+        // Basic validation
+        projectMap.set(p.id, p);
+        importedCount++;
+      }
     });
     const newProjects = Array.from(projectMap.values());
     saveProjects(newProjects);
-    return { success: true, message: `${importedCount} projects successfully imported/updated.`, projectsImported: importedCount };
+    return {
+      success: true,
+      message: `${importedCount} projects successfully imported/updated.`,
+      projectsImported: importedCount,
+    };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error("Import failed:", errorMessage);
+    console.error('Import failed:', errorMessage);
     return { success: false, message: `Import failed: ${errorMessage}` };
   }
 };

--- a/services/metadataService.test.ts
+++ b/services/metadataService.test.ts
@@ -1,16 +1,15 @@
-
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';
-import { getValidatedMetadata } from "./metadataService"; // Adjust path as necessary
+import { getValidatedMetadata } from './metadataService'; // Adjust path as necessary
 import { AppMetadata } from '../types/Metadata'; // Adjust path as necessary
 
 // Mock globalThis.fetch
 const mockFetch = jest.spyOn(globalThis, 'fetch');
 
 const validMetadata: AppMetadata = {
-  name: "IdeaForge Local Test",
-  description: "Test description for metadata validation.",
-  requestFramePermissions: ["camera"],
-  prompt: "Test prompt"
+  name: 'IdeaForge Local Test',
+  description: 'Test description for metadata validation.',
+  requestFramePermissions: ['camera'],
+  prompt: 'Test prompt',
 };
 
 // Helper to create a partial Response object for mocking
@@ -31,8 +30,7 @@ const createMockResponse = (body: any, ok: boolean, status: number, statusText: 
     text: async () => Promise.resolve(JSON.stringify(body)),
     body: null,
     bodyUsed: false,
-  } as unknown as Response);
-
+  }) as unknown as Response;
 
 describe('metadataService - getValidatedMetadata', () => {
   beforeEach(() => {
@@ -48,18 +46,20 @@ describe('metadataService - getValidatedMetadata', () => {
   });
 
   test('should handle optional fields being absent correctly', async () => {
-    const metadataWithoutOptional: Omit<AppMetadata, 'requestFramePermissions' | 'prompt'> & { requestFramePermissions?: string[], prompt?: string } = {
-      name: "App With No Optional Meta",
-      description: "Description here.",
+    const metadataWithoutOptional: Omit<AppMetadata, 'requestFramePermissions' | 'prompt'> & {
+      requestFramePermissions?: string[];
+      prompt?: string;
+    } = {
+      name: 'App With No Optional Meta',
+      description: 'Description here.',
     };
     mockFetch.mockResolvedValueOnce(createMockResponse(metadataWithoutOptional, true, 200, 'OK'));
 
     const metadata = await getValidatedMetadata();
-    expect(metadata.name).toBe("App With No Optional Meta");
+    expect(metadata.name).toBe('App With No Optional Meta');
     expect(metadata.requestFramePermissions).toBeUndefined();
     expect(metadata.prompt).toBeUndefined();
   });
-
 
   test('should throw error if metadata.json fetch fails (network error)', async () => {
     mockFetch.mockRejectedValueOnce(new TypeError('Network failed'));
@@ -68,27 +68,31 @@ describe('metadataService - getValidatedMetadata', () => {
 
   test('should throw error if metadata.json fetch returns non-OK status (e.g., 404)', async () => {
     mockFetch.mockResolvedValueOnce(createMockResponse({}, false, 404, 'Not Found'));
-    await expect(getValidatedMetadata()).rejects.toThrow('Failed to fetch metadata.json: 404 Not Found');
+    await expect(getValidatedMetadata()).rejects.toThrow(
+      'Failed to fetch metadata.json: 404 Not Found'
+    );
   });
 
   test('should throw error if metadata.json response is not valid JSON', async () => {
     const invalidJsonResponse = {
-        ok: true,
-        json: async () => { throw new SyntaxError("Invalid JSON"); }, // json itself throws
-        status: 200,
-        statusText: 'OK',
-        // Add other required Response properties or cast
-        headers: new Headers(),
-        redirected: false,
-        type: 'basic',
-        url: '/metadata.json',
-        clone: () => invalidJsonResponse as Response,
-        arrayBuffer: async () => new ArrayBuffer(0),
-        blob: async () => new Blob(),
-        formData: async () => new FormData(),
-        text: async () => "{invalid json",
-        body: null,
-        bodyUsed: false,
+      ok: true,
+      json: async () => {
+        throw new SyntaxError('Invalid JSON');
+      }, // json itself throws
+      status: 200,
+      statusText: 'OK',
+      // Add other required Response properties or cast
+      headers: new Headers(),
+      redirected: false,
+      type: 'basic',
+      url: '/metadata.json',
+      clone: () => invalidJsonResponse as Response,
+      arrayBuffer: async () => new ArrayBuffer(0),
+      blob: async () => new Blob(),
+      formData: async () => new FormData(),
+      text: async () => '{invalid json',
+      body: null,
+      bodyUsed: false,
     } as Response;
     mockFetch.mockResolvedValueOnce(invalidJsonResponse);
     await expect(getValidatedMetadata()).rejects.toThrow('Invalid JSON');
@@ -128,18 +132,20 @@ describe('metadataService - getValidatedMetadata', () => {
     },
     {
       description: 'prompt is not a string',
-      data: { ...validMetadata, prompt: { text: "hello" } },
+      data: { ...validMetadata, prompt: { text: 'hello' } },
       expectedErrorMsg: /metadata\.prompt: Expected string, received object/i,
     },
   ];
 
-  invalidMetadataTestCases.forEach(testCase => {
+  invalidMetadataTestCases.forEach((testCase) => {
     test(`should throw validation error for invalid metadata: ${testCase.description}`, async () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(testCase.data, true, 200, 'OK'));
 
       await expect(getValidatedMetadata()).rejects.toThrow(
         expect.objectContaining({
-          message: expect.stringMatching(/Invalid metadata\.json structure: .+/) && expect.stringMatching(testCase.expectedErrorMsg),
+          message:
+            expect.stringMatching(/Invalid metadata\.json structure: .+/) &&
+            expect.stringMatching(testCase.expectedErrorMsg),
         })
       );
     });

--- a/services/metadataService.ts
+++ b/services/metadataService.ts
@@ -13,17 +13,19 @@ export const getValidatedMetadata = async (): Promise<AppMetadata> => {
     const validationResult = AppMetadataSchema.safeParse(jsonData);
 
     if (!validationResult.success) {
-      console.error("Metadata validation failed:", validationResult.error.format());
-      const errorMessages = validationResult.error.errors.map(err => `${err.path.join('.') || 'metadata'}: ${err.message}`).join('; ');
+      console.error('Metadata validation failed:', validationResult.error.format());
+      const errorMessages = validationResult.error.errors
+        .map((err) => `${err.path.join('.') || 'metadata'}: ${err.message}`)
+        .join('; ');
       throw new Error(`Invalid metadata.json structure: ${errorMessages}`);
     }
 
     return validationResult.data;
   } catch (error) {
-    console.error("Error loading or validating metadata.json:", error);
+    console.error('Error loading or validating metadata.json:', error);
     if (error instanceof Error) {
-        throw error; // Re-throw the original error or a more specific one
+      throw error; // Re-throw the original error or a more specific one
     }
-    throw new Error("An unknown error occurred while processing metadata.json.");
+    throw new Error('An unknown error occurred while processing metadata.json.');
   }
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -48,7 +48,7 @@ export interface SpacingTokens {
 export interface RadiusTokens {
   sm: string;
   md: string;
-  lg:  string;
+  lg: string;
   xl: string;
   xxl: string;
   card: string;
@@ -83,10 +83,12 @@ export interface ThemeProperties {
 }
 
 // --- Define Base Tokens (used across themes or as defaults) ---
-const baseTypography: Omit<TypographyTokens, 'fontFamilyDisplay'> = { // fontFamilyDisplay is theme-specific
+const baseTypography: Omit<TypographyTokens, 'fontFamilyDisplay'> = {
+  // fontFamilyDisplay is theme-specific
   fontFamilyBody: "'Sora', ui-serif, system-ui",
   fontFamilySans: "'Unbounded', ui-sans-serif, system-ui",
-  fontFamilyMono: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+  fontFamilyMono:
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
   fontScaleRatio: 1.25, // Major Third
   fontSizeBase: '1rem',
 };
@@ -103,12 +105,12 @@ const baseSpacing: SpacingTokens = {
 };
 
 const baseRadii: RadiusTokens = {
-  sm: '0.125rem',   /* 2px */
-  md: '0.25rem',    /* 4px */
-  lg: '0.5rem',     /* 8px */
-  xl: '0.75rem',    /* 12px */
-  xxl: '1rem',      /* 16px */
-  card: 'var(--radius-xl)', /* alias to xl */
+  sm: '0.125rem' /* 2px */,
+  md: '0.25rem' /* 4px */,
+  lg: '0.5rem' /* 8px */,
+  xl: '0.75rem' /* 12px */,
+  xxl: '1rem' /* 16px */,
+  card: 'var(--radius-xl)' /* alias to xl */,
   full: '9999px',
 };
 
@@ -120,11 +122,14 @@ const baseTransitions: TransitionTokens = {
 };
 
 const baseShadows: ShadowTokens = {
-    card: '0 4px 12px rgba(0,0,0,0.15)', // Softer default
-    cardHover: '0 6px 18px rgba(0,0,0,0.2)',
-    glowAccentSm: '0 0 4px var(--color-glow-primary, var(--color-accent-primary)), 0 0 8px var(--color-glow-secondary, var(--color-accent-secondary))',
-    glowAccentMd: '0 0 8px var(--color-glow-primary, var(--color-accent-primary)), 0 0 12px var(--color-glow-secondary, var(--color-accent-secondary))',
-    glowAccentLg: '0 0 12px var(--color-glow-primary, var(--color-accent-primary)), 0 0 20px var(--color-glow-secondary, var(--color-accent-secondary))',
+  card: '0 4px 12px rgba(0,0,0,0.15)', // Softer default
+  cardHover: '0 6px 18px rgba(0,0,0,0.2)',
+  glowAccentSm:
+    '0 0 4px var(--color-glow-primary, var(--color-accent-primary)), 0 0 8px var(--color-glow-secondary, var(--color-accent-secondary))',
+  glowAccentMd:
+    '0 0 8px var(--color-glow-primary, var(--color-accent-primary)), 0 0 12px var(--color-glow-secondary, var(--color-accent-secondary))',
+  glowAccentLg:
+    '0 0 12px var(--color-glow-primary, var(--color-accent-primary)), 0 0 20px var(--color-glow-secondary, var(--color-accent-secondary))',
 };
 
 // --- Theme Definitions ---
@@ -159,7 +164,7 @@ export const darkTheme: ThemeProperties = {
     ...baseShadows,
     card: '0 4px 12px 0 rgba(0,0,0,0.3)', // Original dark theme card shadow
     cardHover: '0 8px 20px 0 rgba(0,0,0,0.35)',
-  }
+  },
 };
 
 export const lightTheme: ThemeProperties = {
@@ -220,11 +225,15 @@ export const cosmicTheme: ThemeProperties = {
   shadows: {
     ...baseShadows,
     card: '0 5px 15px rgba(var(--rgb-accent-primary, 255,0,230), 0.1), 0 2px 8px rgba(var(--rgb-accent-secondary,0,240,255), 0.1)',
-    cardHover: '0 8px 25px rgba(var(--rgb-accent-primary, 255,0,230), 0.2), 0 4px 12px rgba(var(--rgb-accent-secondary,0,240,255), 0.2)',
-    glowAccentSm: '0 0 5px var(--color-glow-primary), 0 0 10px var(--color-glow-primary), 0 0 3px var(--color-glow-secondary)',
-    glowAccentMd: '0 0 10px var(--color-glow-primary), 0 0 20px var(--color-glow-primary), 0 0 6px var(--color-glow-secondary)',
-    glowAccentLg: '0 0 15px var(--color-glow-primary), 0 0 30px var(--color-glow-primary), 0 0 10px var(--color-glow-secondary), 0 0 5px #fff', // Add white hint
-  }
+    cardHover:
+      '0 8px 25px rgba(var(--rgb-accent-primary, 255,0,230), 0.2), 0 4px 12px rgba(var(--rgb-accent-secondary,0,240,255), 0.2)',
+    glowAccentSm:
+      '0 0 5px var(--color-glow-primary), 0 0 10px var(--color-glow-primary), 0 0 3px var(--color-glow-secondary)',
+    glowAccentMd:
+      '0 0 10px var(--color-glow-primary), 0 0 20px var(--color-glow-primary), 0 0 6px var(--color-glow-secondary)',
+    glowAccentLg:
+      '0 0 15px var(--color-glow-primary), 0 0 30px var(--color-glow-primary), 0 0 10px var(--color-glow-secondary), 0 0 5px #fff', // Add white hint
+  },
 };
 
 export const themes: Record<ThemeName, ThemeProperties> = {
@@ -238,6 +247,8 @@ export const themes: Record<ThemeName, ThemeProperties> = {
 // and the useTheme hook (or directly in App.tsx).
 // Tailwind CSS will pick up these CSS variables as defined in its config in index.html.
 
-console.info("styles/theme.ts: Design tokens loaded. Theme application managed via CSS custom properties and theme classes on <html>.");
+console.info(
+  'styles/theme.ts: Design tokens loaded. Theme application managed via CSS custom properties and theme classes on <html>.'
+);
 
 export default themes;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "noUncheckedSideEffectImports": true,
 
     "paths": {
-      "@/*" :  ["./*"]
+      "@/*": ["./*"]
     }
   },
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "node_modules", "coverage"]

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,3 @@
-
-
 export interface Attachment {
   id: string;
   name: string;
@@ -42,11 +40,13 @@ export interface NotificationType {
 }
 
 // For sample project data structure (optional, can be inline)
-export interface SampleIdea extends Omit<Idea, 'id' | 'createdAt' | 'updatedAt' | 'attachments' | 'logo'> {
+export interface SampleIdea
+  extends Omit<Idea, 'id' | 'createdAt' | 'updatedAt' | 'attachments' | 'logo'> {
   attachments?: Omit<Attachment, 'id'>[];
   logo?: string; // Optional: Base64 string for sample blueprint logo
 }
-export interface SampleProject extends Omit<Project, 'id' | 'createdAt' | 'ideas' | 'isFavorite' | 'attachments' | 'logo'> {
+export interface SampleProject
+  extends Omit<Project, 'id' | 'createdAt' | 'ideas' | 'isFavorite' | 'attachments' | 'logo'> {
   ideas: SampleIdea[];
   attachments?: Omit<Attachment, 'id'>[]; // Sample project can also have attachments
   logo?: string;

--- a/utils/zineExporter.ts
+++ b/utils/zineExporter.ts
@@ -27,13 +27,15 @@ export const exportViewAsPdfZine = async (options: ZineExportOptions = {}): Prom
   try {
     const pdf = new jsPDF({
       orientation: 'p', // portrait
-      unit: 'pt',       // points
-      format: 'a4',     // A4 paper size
+      unit: 'pt', // points
+      format: 'a4', // A4 paper size
     });
 
     const elementsToCapture: HTMLElement[] = [];
     if (pageSelector) {
-      document.querySelectorAll<HTMLElement>(pageSelector).forEach(el => elementsToCapture.push(el));
+      document
+        .querySelectorAll<HTMLElement>(pageSelector)
+        .forEach((el) => elementsToCapture.push(el));
     } else {
       // Fallback: try to capture the main app content area
       // This needs a reliable selector for your app's main content wrapper
@@ -42,15 +44,15 @@ export const exportViewAsPdfZine = async (options: ZineExportOptions = {}): Prom
     }
 
     if (elementsToCapture.length === 0) {
-      throw new Error("No content found to export for the Zine.");
+      throw new Error('No content found to export for the Zine.');
     }
 
     for (let i = 0; i < elementsToCapture.length; i++) {
       const element = elementsToCapture[i];
-      
+
       // Ensure element is visible and has dimensions
       // May need to temporarily adjust styles for off-screen or hidden elements if they should be included
-      
+
       const canvas = await html2canvas(element, {
         scale: 2, // Increase scale for better quality
         useCORS: true, // If you have external images
@@ -63,11 +65,11 @@ export const exportViewAsPdfZine = async (options: ZineExportOptions = {}): Prom
       const imgProps = pdf.getImageProperties(imgData);
       const pdfWidth = pdf.internal.pageSize.getWidth();
       const pdfHeight = pdf.internal.pageSize.getHeight();
-      
+
       // Calculate aspect ratio to fit image on page
       const imgWidth = pdfWidth * 0.9; // Use 90% of page width
       const imgHeight = (imgProps.height * imgWidth) / imgProps.width;
-      
+
       let finalImgHeight = imgHeight;
       let finalImgWidth = imgWidth;
 
@@ -75,7 +77,7 @@ export const exportViewAsPdfZine = async (options: ZineExportOptions = {}): Prom
         finalImgHeight = pdfHeight * 0.9;
         finalImgWidth = (imgProps.width * finalImgHeight) / imgProps.height;
       }
-      
+
       const xOffset = (pdfWidth - finalImgWidth) / 2;
       const yOffset = (pdfHeight - finalImgHeight) / 2;
 
@@ -87,11 +89,12 @@ export const exportViewAsPdfZine = async (options: ZineExportOptions = {}): Prom
 
     pdf.save(filename);
     console.log(`Zine exported as ${filename}`);
-
   } catch (error) {
-    console.error("Error exporting Zine:", error);
+    console.error('Error exporting Zine:', error);
     // Optionally, notify the user via UI
-    throw new Error(`Failed to export Zine: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `Failed to export Zine: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,17 +13,17 @@ export default defineConfig(({ mode }) => {
     define: {
       // Expose environment variables to the client.
       // This makes `process.env.API_KEY` available in the code.
-      'process.env.API_KEY': JSON.stringify(env.API_KEY)
+      'process.env.API_KEY': JSON.stringify(env.API_KEY),
     },
     // Server configuration for development
     server: {
       port: 3000, // You can specify a port
-      open: true,   // Automatically open the app in the browser on server start
+      open: true, // Automatically open the app in the browser on server start
     },
     // Build configuration
     build: {
       outDir: 'dist', // Output directory for build files
       sourcemap: true, // Generate source maps for debugging
     },
-  }
+  };
 });


### PR DESCRIPTION
## Summary
- enforce consistent newlines via `.editorconfig`
- ensure LF line endings in Prettier config
- run Prettier formatting on project

## Testing
- `npm run format`
- `npm test` *(fails: Cannot redefine property: JSZip, coverage below threshold)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861ad8c1f2083298741aeaf9dbac204

## Summary by Sourcery

Enforce consistent code style and formatting across the entire codebase by applying Prettier and aligning editor and CI settings. Standardize quotation marks, trailing commas, indentation, and line endings (LF), and introduce a final newline in all files.

Enhancements:
- Apply Prettier formatting to all source, test and configuration files
- Enforce LF line endings via Prettier config and .editorconfig
- Normalize code style (single quotes, trailing commas, consistent spacing) across components, services, hooks, utils and tests

Build:
- Add and enforce editorconfig rules for newline conventions

Tests:
- Reformat existing test files to match the new code style