### PR TITLE
Add temporary node_modules setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Before you begin, ensure you have the following installed:
     ```bash
     npm install
     ```
+    If the `run_in_bash_session` tool fails due to the large number of files created
+    by `npm install`, you can install packages into a temporary directory and
+    symlink `node_modules` back into the repository:
+
+    ```bash
+    scripts/setup-temp-node-modules.sh
+    ```
     Or using yarn:
     ```bash
     yarn install

--- a/scripts/setup-temp-node-modules.sh
+++ b/scripts/setup-temp-node-modules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+TARGET_DIR="${1:-/tmp/ideaforge_modules}"
+
+mkdir -p "$TARGET_DIR"
+cp package.json package-lock.json "$TARGET_DIR/"
+
+# Install dependencies in the temporary directory
+npm install --prefix "$TARGET_DIR"
+
+# Link the node_modules directory back into the repo
+rm -rf node_modules
+ln -s "$TARGET_DIR/node_modules" node_modules


### PR DESCRIPTION
## Summary
- add `setup-temp-node-modules.sh` to install dependencies outside the repo
- document how to use the script in README when `run_in_bash_session` fails

## Testing
- `scripts/setup-temp-node-modules.sh`
- `npm test -- -c jest.config.cjs` *(fails: Jest encountered syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c67caf2348329be35fe6528ac5aa1